### PR TITLE
move dashboard to generate their own configmaps

### DIFF
--- a/charts/conductor/templates/postgres-dashboard.yaml
+++ b/charts/conductor/templates/postgres-dashboard.yaml
@@ -1,10 +1,18 @@
 {{- if .Values.serviceMonitors.coredb.enabled -}}
+{{- $fullName := include "conductor.fullname" . -}}
+{{- $files := .Files -}}
+{{- range $path, $_ := .Files.Glob "dashboards/*" -}}
+{{- $filenameWithExt := base $path -}}
+{{- $filename := trimSuffix ".json" $filenameWithExt -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "conductor.fullname" . }}-postgres-dashboard
+  name: {{ $fullName }}-{{ $filename }}
   labels:
     grafana_dashboard: "1"
 data:
-{{ (.Files.Glob "dashboards/*").AsConfig | indent 2 }}
+  {{ $filename }}: |-
+{{ ($files.Get $path) | indent 4 }}
 {{- end }}
+{{- end }}
+


### PR DESCRIPTION
If we have too many dashboards, it will cause the `ConfigMap` update to fail due to the size being too large for a single `ConfigMap`.

Move every dashboard into their own specific `ConfigMap`