### PR TITLE
[TEM-1407] Allow nodes to be scaled down by default

### DIFF
--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -8,7 +8,7 @@ use crate::{
             ClusterBackupBarmanObjectStoreWal, ClusterBackupBarmanObjectStoreWalCompression,
             ClusterBackupBarmanObjectStoreWalEncryption, ClusterBootstrap, ClusterBootstrapInitdb,
             ClusterExternalClusters, ClusterExternalClustersPassword, ClusterLogLevel, ClusterMonitoring,
-            ClusterMonitoringCustomQueriesConfigMap, ClusterPostgresql,
+            ClusterMonitoringCustomQueriesConfigMap, ClusterNodeMaintenanceWindow, ClusterPostgresql,
             ClusterPostgresqlSyncReplicaElectionConstraint, ClusterPrimaryUpdateMethod,
             ClusterPrimaryUpdateStrategy, ClusterResources, ClusterServiceAccountTemplate,
             ClusterServiceAccountTemplateMetadata, ClusterSpec, ClusterStorage, ClusterSuperuserSecret,
@@ -30,7 +30,6 @@ use kube::{
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::time::Duration;
 use tracing::{debug, error, info, warn};
-use crate::cloudnativepg::clusters::ClusterNodeMaintenanceWindow;
 
 pub struct PostgresConfig {
     pub postgres_parameters: Option<BTreeMap<String, String>>,
@@ -325,7 +324,7 @@ pub fn cnpg_cluster_from_cdb(cdb: &CoreDB) -> Cluster {
             // to gracefully shutdown during a switchover
             switchover_delay: Some(60),
             // Set this to match when the cluster consolidation happens
-            node_maintenance_window: Some(ClusterNodeMaintenanceWindow{
+            node_maintenance_window: Some(ClusterNodeMaintenanceWindow {
                 // TODO TEM-1407: Make this configurable and aligned with cluster scale down
                 // default to in_progress: true - otherwise single-instance CNPG clusters
                 // prevent cluster scale down.

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -30,6 +30,7 @@ use kube::{
 use std::{collections::BTreeMap, sync::Arc};
 use tokio::time::Duration;
 use tracing::{debug, error, info, warn};
+use crate::cloudnativepg::clusters::ClusterNodeMaintenanceWindow;
 
 pub struct PostgresConfig {
     pub postgres_parameters: Option<BTreeMap<String, String>>,
@@ -324,7 +325,13 @@ pub fn cnpg_cluster_from_cdb(cdb: &CoreDB) -> Cluster {
             // to gracefully shutdown during a switchover
             switchover_delay: Some(60),
             // Set this to match when the cluster consolidation happens
-            node_maintenance_window: None,
+            node_maintenance_window: Some(ClusterNodeMaintenanceWindow{
+                // TODO TEM-1407: Make this configurable and aligned with cluster scale down
+                // default to in_progress: true - otherwise single-instance CNPG clusters
+                // prevent cluster scale down.
+                in_progress: true,
+                ..ClusterNodeMaintenanceWindow::default()
+            }),
             ..ClusterSpec::default()
         },
         status: None,


### PR DESCRIPTION
https://cloudnative-pg.io/documentation/1.20/kubernetes_upgrade/#single-instance-clusters-with-reusepvc-set-to-false

> As long as a database service downtime is acceptable for your environment, draining the node is as simple as setting the nodeMaintenanceWindow to inProgress: true and reusePVC: true. This will allow the instance to be deleted and recreated as soon as the original PVC is available (e.g. with node local storage, as soon as the node is back up).

Currently, the k8s cluster doesn't scale down because the pod disruption budgets from CNPG prevent it. CNPG's logic is to prevent a node from being scaled down unless all the CNPG clusters on it have this setting enabled. Adding this configuration will allow cluster to scale down during the configured maintenance window. Leaving it as True all the time like set in this PR doesn't protect against a node getting drained outside of the maintenance window, so we should match up this configuration to our actual node consolidation schedule, which is covered in the Tembo ticket TEM-1407.

```
Events:
  Type    Reason                 Age                   From       Message
  ----    ------                 ----                  ----       -------
  Normal  Unconsolidatable       18m (x35 over 8h)     karpenter  provisioner default has consolidation disabled
  Normal  DeprovisioningBlocked  2m55s (x2 over 8m5s)  karpenter  Cannot deprovision node due to pdb org-coredb-inst-nhudson-test-dev/org-coredb-inst-nhudson-test-dev-primary prevents pod evictions
  Normal  DeprovisioningBlocked  89s                   karpenter  Cannot deprovision node due to pdb org-coredb-inst-nhudson-test-dev/org-coredb-inst-nhudson-test-dev-primary prevents pod evictions
  ```