### PR TITLE
Update rust version conductor

### DIFF
--- a/conductor/.gitignore
+++ b/conductor/.gitignore
@@ -1,1 +1,3 @@
 .idea/**
+tembo-operator/
+tembo-operator/**

--- a/conductor/Dockerfile
+++ b/conductor/Dockerfile
@@ -6,10 +6,11 @@ RUN apt-get update && \
 
 COPY tembo-operator ./tembo-operator
 WORKDIR /build
-COPY Cargo.toml Cargo.lock ./
-COPY src ./src
-RUN cargo build --release && \
-    cargo clean -p conductor
+
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY ./src ./src
+
 RUN cargo install --path .
 
 FROM quay.io/coredb/debian:11.6-slim

--- a/conductor/Dockerfile
+++ b/conductor/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coredb/rust:1.66.1 as builder
+FROM quay.io/coredb/rust:1.71.0-slim-buster as builder
 COPY tembo-operator ./tembo-operator
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./

--- a/conductor/Dockerfile
+++ b/conductor/Dockerfile
@@ -1,4 +1,9 @@
 FROM quay.io/coredb/rust:1.71.0-slim-buster as builder
+
+RUN apt-get update && \
+    apt-get install -y pkg-config libssl-dev && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 COPY tembo-operator ./tembo-operator
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
```
error: failed to compile `conductor v0.1.0 (/build)`, intermediate artifacts can be found at `/build/target`

Caused by:
  package `time v0.3.24` cannot be built because it requires rustc 1.67.0 or newer, while the currently active rustc version is 1.66.1
  Either upgrade to rustc 1.67.0 or newer, or use
  cargo update -p time@0.3.24 --precise ver
  where `ver` is the latest version of `time` supporting rustc 1.66.1
The command '/bin/sh -c cargo install --path .' returned a non-zero code: 101
```