### PR TITLE
make extension schema specification optional

### DIFF
--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -66,7 +66,7 @@ spec:
                           enabled:
                             type: boolean
                           schema:
-                            default: public
+                            nullable: true
                             type: string
                           version:
                             nullable: true
@@ -363,7 +363,7 @@ spec:
                           enabled:
                             type: boolean
                           schema:
-                            default: public
+                            nullable: true
                             type: string
                           version:
                             nullable: true

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -69,10 +69,6 @@ pub fn default_database() -> String {
     "postrgres".to_owned()
 }
 
-pub fn default_schema() -> String {
-    "public".to_owned()
-}
-
 pub fn default_description() -> Option<String> {
     Some("No description provided".to_owned())
 }

--- a/tembo-operator/src/extensions.rs
+++ b/tembo-operator/src/extensions.rs
@@ -569,6 +569,16 @@ mod tests {
             "CREATE EXTENSION IF NOT EXISTS \"my_ext\" SCHEMA public CASCADE;"
         );
 
+        // drop extension
+        let loc2 = ExtensionInstallLocation {
+            database: "postgres".to_string(),
+            enabled: false,
+            schema: Some("public".to_string()),
+            version: Some("1.0.0".to_string()),
+        };
+        let cmd = generate_extension_enable_cmd("my_ext", &loc2);
+        assert_eq!(cmd.unwrap(), "DROP EXTENSION IF EXISTS \"my_ext\" CASCADE;");
+
         // error mode: malformed database name
         let loc2 = ExtensionInstallLocation {
             database: "postgres; --".to_string(),


### PR DESCRIPTION
Only specify `SCHEMA` in the `CREATE EXTENSION` statement when its explicitly provided.

Refactored part of `toggle_extensions()` in order to add tests around this functionality.