### PR TITLE
Add more extension name mappings

### DIFF
--- a/tembo-operator/src/extensions.rs
+++ b/tembo-operator/src/extensions.rs
@@ -27,6 +27,21 @@ lazy_static! {
         m.insert("pgml", "postgresml");
         m.insert("columnar", "hydra_columnar");
         m.insert("currency", "pg_currency");
+        m.insert("emailaddr", "pgemailaddr");
+        m.insert("financial", "pg_financial");
+        m.insert("roaringbitmap", "pg_roaringbitmap");
+        m.insert("semver", "pg_semver");
+        m.insert("http", "pgsql_http");
+        m.insert("ogr_fdw", "pgsql_ogr_fdw");
+        m.insert("timeit", "pg_timeit");
+        m.insert("uint", "pguint");
+        m.insert("uri", "pguri");
+        m.insert("decoderbufs", "postgres_decoderbufs");
+        m.insert("anon", "postgresql_anonymizer");
+        m.insert("hll", "postgresql_hll");
+        m.insert("topn", "postgresql_topn");
+        m.insert("unit", "postgresql_unit");
+        m.insert("uuid-ossp", "uuid_ossp");
         m
     };
 }


### PR DESCRIPTION
Add name mappings for:
- https://pgt.dev/extensions/pgemailaddr
- https://pgt.dev/extensions/pg_financial
- https://pgt.dev/extensions/pg_roaringbitmap
- https://pgt.dev/extensions/pg_semver
- https://pgt.dev/extensions/pgsql_http
- https://pgt.dev/extensions/pgsql_ogr_fdw
- https://pgt.dev/extensions/pg_timeit
- https://pgt.dev/extensions/pguint
- https://pgt.dev/extensions/pguri
- https://pgt.dev/extensions/postgres_decoderbufs
- https://pgt.dev/extensions/postgresql_anonymizer
- https://pgt.dev/extensions/postgresql_hll
- https://pgt.dev/extensions/postgresql_topn
- https://pgt.dev/extensions/postgresql_unit
- https://pgt.dev/extensions/uuid_ossp