### PR TITLE
fix logic where we add metrics volume

### DIFF
--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -141,9 +141,15 @@ impl CoreDB {
             }
         };
 
-        if self.spec.postgresExporterEnabled {
+        if self.spec.postgresExporterEnabled
+            && self
+                .spec
+                .metrics
+                .as_ref()
+                .and_then(|m| m.queries.as_ref())
+                .is_some()
+        {
             debug!("Reconciling prometheus configmap");
-            // Configmap for extra prometheus exporter metrics
             reconcile_prom_configmap(self, client.clone(), &ns)
                 .await
                 .map_err(|e| {

--- a/tembo-operator/src/postgres_exporter.rs
+++ b/tembo-operator/src/postgres_exporter.rs
@@ -156,6 +156,8 @@ pub async fn reconcile_prom_configmap(cdb: &CoreDB, client: Client, ns: &str) ->
         .name
         .clone()
         .expect("instance should always have a name");
+    // Make sure we always check for queries in the spec, incase someone calls this function
+    // directly and not through the reconcile function.
     match cdb.spec.metrics.clone().and_then(|m| m.queries) {
         Some(queries) => {
             let qdata = serde_yaml::to_string(&queries).unwrap();


### PR DESCRIPTION
The previous logic will always add a volume to the deployment mainly because `cdb.spec.metrics` is never empty by default, or at least shouldn't be.  New logic should handle the case correctly, where we only want to mount the `ConfgMap` if there are configured queries.

```
spec:
  metrics:
    enabled: true
    image: quay.io/prometheuscommunity/postgres-exporter:v0.12.0
```