### PR TITLE
Do not add `volumeMount` if there isn't a `volume`

### DIFF
--- a/tembo-operator/src/deployment_postgres_exporter.rs
+++ b/tembo-operator/src/deployment_postgres_exporter.rs
@@ -125,17 +125,18 @@ pub async fn reconcile_prometheus_exporter_deployment(cdb: &CoreDB, ctx: Arc<Con
     ];
 
     // Generate VolumeMounts for the Container
-    let exporter_vol_mounts = match cdb.spec.metrics {
-        None => {
-            vec![]
-        }
-        Some(_) => {
+    let exporter_vol_mounts = if let Some(metrics) = &cdb.spec.metrics {
+        if metrics.queries.is_some() {
             vec![VolumeMount {
                 name: EXPORTER_VOLUME.to_owned(),
                 mount_path: PROM_CFG_DIR.to_string(),
                 ..VolumeMount::default()
             }]
+        } else {
+            vec![]
         }
+    } else {
+        vec![]
     };
 
     // Generate Volumes for the PodSpec


### PR DESCRIPTION
Correct logic to follow the same pattern as `exporter_volumes`.  This should make sure that no `volumeMounts` are created unless there are `volumes` to mount.