### PR TITLE
Enable HA/Replication Slots

### DIFF
--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -83,7 +83,7 @@ start-kind:
 
 # run with opentelemetry
 run-telemetry:
-	DATA_PLANE_BASEDOMAIN=localhost OPENTELEMETRY_ENDPOINT_URL=http://localhost:4318 RUST_LOG=debug,kube=debug,controller=debug ENABLE_BACKUP=false cargo run --features=telemetry
+	DATA_PLANE_BASEDOMAIN=localhost OPENTELEMETRY_ENDPOINT_URL=http://localhost:4317 RUST_LOG=debug,kube=debug,controller=debug ENABLE_BACKUP=false cargo run --features=telemetry
 
 # run without opentelemetry
 run:
@@ -109,7 +109,7 @@ watch:
 
 # watch with opentelemetry
 watch-telemetry:
-	DATA_PLANE_BASEDOMAIN=localhost OPENTELEMETRY_ENDPOINT_URL=http://localhost:4318 RUST_LOG=debug,kube=debug,controller=debug ENABLE_BACKUP=false cargo watch -x 'run --features=telemetry'
+	DATA_PLANE_BASEDOMAIN=localhost OPENTELEMETRY_ENDPOINT_URL=http://localhost:4317 RUST_LOG=debug,kube=debug,controller=debug ENABLE_BACKUP=false cargo watch -x 'run --features=telemetry'
 
 # format with nightly rustfmt
 fmt:

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -10,8 +10,9 @@ use crate::{
             ClusterExternalClusters, ClusterExternalClustersPassword, ClusterLogLevel, ClusterMonitoring,
             ClusterMonitoringCustomQueriesConfigMap, ClusterNodeMaintenanceWindow, ClusterPostgresql,
             ClusterPostgresqlSyncReplicaElectionConstraint, ClusterPrimaryUpdateMethod,
-            ClusterPrimaryUpdateStrategy, ClusterResources, ClusterServiceAccountTemplate,
-            ClusterServiceAccountTemplateMetadata, ClusterSpec, ClusterStorage, ClusterSuperuserSecret,
+            ClusterPrimaryUpdateStrategy, ClusterReplicationSlots, ClusterReplicationSlotsHighAvailability,
+            ClusterResources, ClusterServiceAccountTemplate, ClusterServiceAccountTemplateMetadata,
+            ClusterSpec, ClusterStorage, ClusterSuperuserSecret,
         },
         scheduledbackups::{
             ScheduledBackup, ScheduledBackupBackupOwnerReference, ScheduledBackupCluster, ScheduledBackupSpec,
@@ -235,20 +236,32 @@ fn cnpg_cluster_storage(cdb: &CoreDB) -> Option<ClusterStorage> {
     })
 }
 
+// Check replica count to enable HA
+fn cnpg_high_availability(cdb: &CoreDB) -> Option<ClusterReplicationSlots> {
+    if cdb.spec.replicas > 1 {
+        Some(ClusterReplicationSlots {
+            high_availability: Some(ClusterReplicationSlotsHighAvailability {
+                enabled: Some(true),
+                ..ClusterReplicationSlotsHighAvailability::default()
+            }),
+            update_interval: Some(30),
+        })
+    } else {
+        None
+    }
+}
+
 pub fn cnpg_cluster_from_cdb(cdb: &CoreDB) -> Cluster {
     let cfg = Config::default();
     let name = cdb.name_any();
     let namespace = cdb.namespace().unwrap();
     let owner_reference = cdb.controller_owner_ref(&()).unwrap();
-
     let mut annotations = BTreeMap::new();
     annotations.insert("tembo-pod-init.tembo.io/inject".to_string(), "true".to_string());
-
     let (bootstrap, external_clusters, superuser_secret) = cnpg_cluster_bootstrap_from_cdb(cdb);
-
     let (backup, service_account_template) = cnpg_backup_configuration(cdb, &cfg);
-
     let storage = cnpg_cluster_storage(cdb);
+    let replication = cnpg_high_availability(cdb);
 
     let PostgresConfig {
         postgres_parameters,
@@ -297,7 +310,7 @@ pub fn cnpg_cluster_from_cdb(cdb: &CoreDB) -> Cluster {
             enable_superuser_access: Some(true),
             failover_delay: Some(0),
             image_name: Some(image),
-            instances: 1,
+            instances: cdb.spec.replicas as i64,
             log_level: Some(ClusterLogLevel::Info),
             max_sync_replicas: Some(0),
             min_sync_replicas: Some(0),
@@ -325,6 +338,7 @@ pub fn cnpg_cluster_from_cdb(cdb: &CoreDB) -> Cluster {
             }),
             primary_update_method: Some(ClusterPrimaryUpdateMethod::Restart),
             primary_update_strategy: Some(ClusterPrimaryUpdateStrategy::Unsupervised),
+            replication_slots: replication,
             resources: Some(ClusterResources {
                 claims: None,
                 limits: cdb.spec.resources.clone().limits,

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -247,7 +247,13 @@ fn cnpg_high_availability(cdb: &CoreDB) -> Option<ClusterReplicationSlots> {
             update_interval: Some(30),
         })
     } else {
-        None
+        Some(ClusterReplicationSlots {
+            high_availability: Some(ClusterReplicationSlotsHighAvailability {
+                enabled: Some(false),
+                ..ClusterReplicationSlotsHighAvailability::default()
+            }),
+            update_interval: Some(30),
+        })
     }
 }
 

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -118,8 +118,3 @@ pub fn default_backup_schedule() -> Option<String> {
     // Every day at midnight
     Some("0 0 * * *".to_owned())
 }
-
-pub fn enable_replication_slots() -> Option<bool> {
-    // Do not enable HA by default
-    Some(false)
-}

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -118,3 +118,8 @@ pub fn default_backup_schedule() -> Option<String> {
     // Every day at midnight
     Some("0 0 * * *".to_owned())
 }
+
+pub fn enable_replication_slots() -> Option<bool> {
+    // Do not enable HA by default
+    Some(false)
+}

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1476,9 +1476,6 @@ mod test {
             },
             "spec": {
                 "replicas": replicas,
-                "high_availability": {
-                    "enable_replication_slots": true,
-                }
             }
         });
         let params = PatchParams::apply("tembo-integration-test");

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1580,13 +1580,13 @@ mod test {
         let pod_name_primary = format!("{}-1", name);
         pod_ready_and_running(pods.clone(), pod_name_primary.clone()).await;
 
-        // Assert that we can query the database with \dt;
+        // Assert that we can query the database with \dx;
         let result = coredb_resource
-            .psql("\\dt".to_string(), "postgres".to_string(), context.clone())
+            .psql("\\dx".to_string(), "postgres".to_string(), context.clone())
             .await
             .unwrap();
         println!("psql out: {}", result.stdout.clone().unwrap());
-        assert!(!result.stdout.clone().unwrap().contains("postgres"));
+        assert!(result.stdout.clone().unwrap().contains("plpgsql"));
 
         // Now upgrade the single instance to be HA
         let replicas = 2;
@@ -1609,13 +1609,13 @@ mod test {
         let pod_name_secondary = format!("{}-2", name);
         pod_ready_and_running(pods.clone(), pod_name_secondary.clone()).await;
 
-        // Assert that we can query the database again now that HA is enabled with \dt;
+        // Assert that we can query the database again now that HA is enabled with \dx;
         let result = coredb_resource
-            .psql("\\dt".to_string(), "postgres".to_string(), context.clone())
+            .psql("\\dx".to_string(), "postgres".to_string(), context.clone())
             .await
             .unwrap();
         println!("psql out: {}", result.stdout.clone().unwrap());
-        assert!(!result.stdout.clone().unwrap().contains("postgres"));
+        assert!(result.stdout.clone().unwrap().contains("plpgsql"));
 
         // Assert that both pods are replicating successfully
         let result = coredb_resource

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1437,4 +1437,215 @@ mod test {
         // Delete namespace
         let _ = delete_namespace(client.clone(), &namespace).await;
     }
+
+    #[tokio::test]
+    #[ignore]
+    async fn functional_test_ha_basic_cnpg() {
+        // Initialize the Kubernetes client
+        let client = kube_client().await;
+        let state = State::default();
+        let context = state.create_context(client.clone());
+
+        // Configurations
+        let mut rng = rand::thread_rng();
+        let suffix = rng.gen_range(0..100000);
+        let name = &format!("test-coredb-{}", suffix);
+        let namespace = match create_namespace(client.clone(), name).await {
+            Ok(namespace) => namespace,
+            Err(e) => {
+                eprintln!("Error creating namespace: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        let kind = "CoreDB";
+        let replicas = 2;
+
+        // Create a pod we can use to run commands in the cluster
+        let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+
+        // Apply a basic configuration of CoreDB
+        println!("Creating CoreDB resource {}", name);
+        let coredbs: Api<CoreDB> = Api::namespaced(client.clone(), &namespace);
+        // Generate basic CoreDB resource to start with
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "replicas": replicas,
+                "high_availability": {
+                    "enable_replication_slots": true,
+                }
+            }
+        });
+        let params = PatchParams::apply("tembo-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        // Wait for CNPG Pod to be created
+        let pod_name_primary = format!("{}-1", name);
+        let pod_name_secondary = format!("{}-2", name);
+
+        pod_ready_and_running(pods.clone(), pod_name_primary.clone()).await;
+        pod_ready_and_running(pods.clone(), pod_name_secondary.clone()).await;
+
+        // Assert that we can query the database with \dt;
+        let result = coredb_resource
+            .psql("\\dt".to_string(), "postgres".to_string(), context.clone())
+            .await
+            .unwrap();
+        println!("psql out: {}", result.stdout.clone().unwrap());
+        assert!(!result.stdout.clone().unwrap().contains("postgres"));
+
+        // Assert that both pods are replicating successfully
+        let result = coredb_resource
+            .psql(
+                "SELECT state FROM pg_stat_replication".to_string(),
+                "postgres".to_string(),
+                context.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(result.stdout.clone().unwrap().contains("streaming"));
+
+        // CLEANUP TEST
+        // Cleanup CoreDB
+        coredbs.delete(name, &Default::default()).await.unwrap();
+        println!("Waiting for CoreDB to be deleted: {}", &name);
+        let _assert_coredb_deleted = tokio::time::timeout(
+            Duration::from_secs(TIMEOUT_SECONDS_COREDB_DELETED),
+            await_condition(coredbs.clone(), name, conditions::is_deleted("")),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "CoreDB {} was not deleted after waiting {} seconds",
+                name, TIMEOUT_SECONDS_COREDB_DELETED
+            )
+        });
+        println!("CoreDB resource deleted {}", name);
+
+        // Delete namespace
+        let _ = delete_namespace(client.clone(), &namespace).await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn functional_test_ha_upgrade_cnpg() {
+        // Initialize the Kubernetes client
+        let client = kube_client().await;
+        let state = State::default();
+        let context = state.create_context(client.clone());
+
+        // Configurations
+        let mut rng = rand::thread_rng();
+        let suffix = rng.gen_range(0..100000);
+        let name = &format!("test-coredb-{}", suffix);
+        let namespace = match create_namespace(client.clone(), name).await {
+            Ok(namespace) => namespace,
+            Err(e) => {
+                eprintln!("Error creating namespace: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        let kind = "CoreDB";
+        let replicas = 1;
+
+        // Create a pod we can use to run commands in the cluster
+        let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+
+        // Apply a basic configuration of CoreDB
+        println!("Creating CoreDB resource {}", name);
+        let coredbs: Api<CoreDB> = Api::namespaced(client.clone(), &namespace);
+        // Generate basic CoreDB resource to start with
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "replicas": replicas,
+            }
+        });
+        let params = PatchParams::apply("tembo-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        // Wait for CNPG Pod to be created
+        let pod_name_primary = format!("{}-1", name);
+        pod_ready_and_running(pods.clone(), pod_name_primary.clone()).await;
+
+        // Assert that we can query the database with \dt;
+        let result = coredb_resource
+            .psql("\\dt".to_string(), "postgres".to_string(), context.clone())
+            .await
+            .unwrap();
+        println!("psql out: {}", result.stdout.clone().unwrap());
+        assert!(!result.stdout.clone().unwrap().contains("postgres"));
+
+        // Now upgrade the single instance to be HA
+        let replicas = 2;
+        // Generate HA CoreDB resource
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "replicas": replicas,
+            }
+        });
+        let params = PatchParams::apply("tembo-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        // Wait for new CNPG secondary Pod to be created and running
+        let pod_name_secondary = format!("{}-2", name);
+        pod_ready_and_running(pods.clone(), pod_name_secondary.clone()).await;
+
+        // Assert that we can query the database again now that HA is enabled with \dt;
+        let result = coredb_resource
+            .psql("\\dt".to_string(), "postgres".to_string(), context.clone())
+            .await
+            .unwrap();
+        println!("psql out: {}", result.stdout.clone().unwrap());
+        assert!(!result.stdout.clone().unwrap().contains("postgres"));
+
+        // Assert that both pods are replicating successfully
+        let result = coredb_resource
+            .psql(
+                "SELECT state FROM pg_stat_replication".to_string(),
+                "postgres".to_string(),
+                context.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(result.stdout.clone().unwrap().contains("streaming"));
+
+        // CLEANUP TEST
+        // Cleanup CoreDB
+        coredbs.delete(name, &Default::default()).await.unwrap();
+        println!("Waiting for CoreDB to be deleted: {}", &name);
+        let _assert_coredb_deleted = tokio::time::timeout(
+            Duration::from_secs(TIMEOUT_SECONDS_COREDB_DELETED),
+            await_condition(coredbs.clone(), name, conditions::is_deleted("")),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "CoreDB {} was not deleted after waiting {} seconds",
+                name, TIMEOUT_SECONDS_COREDB_DELETED
+            )
+        });
+        println!("CoreDB resource deleted {}", name);
+
+        // Delete namespace
+        let _ = delete_namespace(client.clone(), &namespace).await;
+    }
 }


### PR DESCRIPTION
This PR is meant to add the ability to enable HA/Replication Slots configuration into the Tembo Cloud stack.

* The operator will now automatically enable HA when 2 or more replicas are set in the `CoreDBSpec`.
* We now respect the value of `replicas` and it will set the replica/instance count from `spec.replicas`

Fixes: [TEM-1384](https://linear.app/tembo/issue/TEM-1384)