### PR TITLE
Add connection string info for app user

### DIFF
--- a/conductor/src/aws/cloudformation.rs
+++ b/conductor/src/aws/cloudformation.rs
@@ -151,7 +151,7 @@ impl AWSConfigState {
                 }
                 Err(err) => {
                     error!("Error creating stack: {:?}", err);
-                    Err(ConductorError::AwsError(err.into()))
+                    Err(ConductorError::AwsError(Box::new(err.into())))
                 }
             }
         } else {
@@ -179,7 +179,7 @@ impl AWSConfigState {
                 }
                 Err(err) => {
                     error!("Error deleting stack: {:?}", err);
-                    Err(ConductorError::AwsError(err.into()))
+                    Err(ConductorError::AwsError(Box::new(err.into())))
                 }
             }
         } else {
@@ -228,7 +228,7 @@ impl AWSConfigState {
             }
             Err(err) => {
                 error!("Error describing stack: {:?}", err);
-                Err(ConductorError::AwsError(err.into()))
+                Err(ConductorError::AwsError(Box::new(err.into())))
             }
         }
     }

--- a/conductor/src/errors.rs
+++ b/conductor/src/errors.rs
@@ -28,7 +28,7 @@ pub enum ConductorError {
 
     /// a aws error
     #[error("aws sdk error {0}")]
-    AwsError(#[from] CFError),
+    AwsError(#[from] Box<CFError>),
 
     // No outputs found for the stack
     #[error("no outputs found for the stack")]

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -21,7 +21,7 @@ use chrono::{SecondsFormat, Utc};
 use kube::{Api, Client};
 use log::{debug, info};
 use rand::Rng;
-use serde_json::{from_str, to_string, Value};
+use serde_json::Value;
 
 pub type Result<T, E = ConductorError> = std::result::Result<T, E>;
 
@@ -290,56 +290,102 @@ pub async fn delete_namespace(client: Client, name: &str) -> Result<(), Conducto
     Ok(())
 }
 
-async fn get_secret_for_db(client: Client, name: &str) -> Result<Secret, ConductorError> {
+async fn get_secret_for_db(client: Client, name: &str) -> Result<(Secret, Secret), ConductorError> {
     // read secret <name>-connection
-    let secret_name_cdb = format!("{name}-connection");
-    let secret_name_cnpg = format!("{name}-superuser");
+    let secret_name_cnpg_postgres = format!("{name}-connection");
+    let secret_name_cnpg_app = format!("{name}-app");
 
     let secret_api: Api<Secret> = Api::namespaced(client, name);
 
-    if let Some(secret) = secret_api.get_opt(secret_name_cnpg.as_str()).await? {
-        debug!("Found the secret {}", secret_name_cnpg);
-        Ok(secret)
-    } else {
-        debug!(
-            "Didn't find the secret {}, trying cdb-style {}",
-            secret_name_cnpg, secret_name_cdb
-        );
-        if let Some(secret) = secret_api.get_opt(secret_name_cdb.as_str()).await? {
-            debug!("Found the secret {}", secret_name_cdb);
-            Ok(secret)
-        } else {
-            debug!("Didn't find the secret {}", secret_name_cdb);
-            Err(ConductorError::PostgresConnectionInfoNotFound)
+    // Get the <name>-connection secret
+    let postgres_user_secret = match secret_api
+        .get_opt(secret_name_cnpg_postgres.as_str())
+        .await?
+    {
+        Some(secret) => {
+            debug!("Found the secret {}", secret_name_cnpg_postgres);
+            secret
         }
+        None => {
+            debug!("Didn't find the secret {}", secret_name_cnpg_postgres);
+            return Err(ConductorError::PostgresConnectionInfoNotFound);
+        }
+    };
+
+    // Get the <name>-app secret
+    let app_user_secret = match secret_api.get_opt(secret_name_cnpg_app.as_str()).await? {
+        Some(secret) => {
+            debug!("Found the secret {}", secret_name_cnpg_app);
+            secret
+        }
+        None => {
+            debug!("Didn't find the secret {}", secret_name_cnpg_app);
+            return Err(ConductorError::PostgresConnectionInfoNotFound);
+        }
+    };
+
+    Ok((postgres_user_secret, app_user_secret))
+}
+
+// Helper function to extract a string field from the secret data
+fn extract_field(
+    data: &std::collections::BTreeMap<String, k8s_openapi::ByteString>,
+    field: &str,
+) -> Result<String, ConductorError> {
+    match data.get(field) {
+        Some(k8s_openapi::ByteString(vec)) => {
+            let string_data = std::str::from_utf8(vec)
+                .map_err(|_| ConductorError::ParsingPostgresConnectionError)?;
+            Ok(string_data.to_string())
+        }
+        None => Err(ConductorError::PostgresConnectionInfoNotFound),
     }
+}
+
+// get_connection_string returns the username and password from the secret
+async fn get_connection_string(secret: Secret) -> Result<(String, String), ConductorError> {
+    let data = secret
+        .data
+        .ok_or(ConductorError::PostgresConnectionInfoNotFound)?;
+
+    let string_user = extract_field(&data, "username")?;
+    let string_pw = extract_field(&data, "password")?;
+
+    Ok((string_user, string_pw))
 }
 
 pub async fn get_pg_conn(
     client: Client,
     name: &str,
     basedomain: &str,
-) -> Result<types::ConnectionInfo, ConductorError> {
-    let secret = get_secret_for_db(client, name).await?;
+) -> Result<(types::ConnectionInfo, types::ConnectionInfo), ConductorError> {
+    let (postgres_user_secret, app_user_secret) = get_secret_for_db(client, name).await?;
 
-    let data = secret.data.unwrap();
+    // Get the postgres user and password from postgres_user_secret
+    let (postgres_string_user, postgres_string_pw) =
+        get_connection_string(postgres_user_secret).await?;
 
-    let user_data = data.get("user").unwrap();
-    let byte_user = to_string(user_data).unwrap();
-    let string_user: String = from_str(&byte_user).unwrap();
-
-    let pw_data = data.get("password").unwrap();
-    let byte_pw = to_string(pw_data).unwrap();
-    let string_pw: String = from_str(&byte_pw).unwrap();
+    let (app_string_user, app_string_pw) = get_connection_string(app_user_secret).await?;
 
     let host = format!("{name}.{basedomain}");
 
-    Ok(types::ConnectionInfo {
-        host,
+    // Create ConnectionInfo for the postgres user
+    let postgres_conn = types::ConnectionInfo {
+        host: host.clone(),
         port: 5432,
-        user: string_user,
-        password: string_pw,
-    })
+        user: postgres_string_user,
+        password: postgres_string_pw,
+    };
+
+    // Create ConnectionInfo for the app user
+    let app_conn = types::ConnectionInfo {
+        host: host.clone(),
+        port: 5432,
+        user: app_string_user,
+        password: app_string_pw,
+    };
+
+    Ok((postgres_conn, app_conn))
 }
 
 pub async fn restart_statefulset(

--- a/conductor/src/status_reporter.rs
+++ b/conductor/src/status_reporter.rs
@@ -97,8 +97,14 @@ async fn send_status_update(
             return Ok(());
         }
     };
-    let conn_info = match get_pg_conn(client, &namespace, &data_plane_basedomain).await {
-        Ok(conn_info) => conn_info,
+    let (conn_info_pg, conn_info_app) = match get_pg_conn(
+        client,
+        &namespace,
+        &data_plane_basedomain,
+    )
+    .await
+    {
+        Ok((conn_pg, conn_app)) => (conn_pg, conn_app),
         Err(_) => {
             info!("Could not get connection info for CoreDB {}, skipping status update. This can be normal for a few seconds when the resource is initially created, and when the instance is being deleted.", coredb_name);
             return Ok(());
@@ -110,7 +116,7 @@ async fn send_status_update(
         event_type: Event::Updated,
         spec: Some(coredb.spec.clone()),
         status: coredb.status.clone(),
-        connection: Some(conn_info),
+        connection: Some((conn_info_pg, conn_info_app)),
     };
     let msg_id = response_queue
         .send(&data_plane_events_queue, &response)

--- a/conductor/src/types.rs
+++ b/conductor/src/types.rs
@@ -40,7 +40,7 @@ pub struct StateToControlPlane {
     pub event_type: Event,     // pass through from event that triggered a data plane action
     pub spec: Option<CoreDBSpec>,
     pub status: Option<CoreDBStatus>,
-    pub connection: Option<types::ConnectionInfo>,
+    pub connection: Option<(types::ConnectionInfo, types::ConnectionInfo)>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This PR changes how we send back connection string information to the control-plane.  This will include the connection string info for both the `postgres` and `app` users. 

Some things to note for this change:  This will most likely break Mahout and rendering of the connection info.  I am not sure what would need to be changed to get that working with this change yet.

* Changes the response back to the control-plane from a single `ConnectionInfo` into a tuple of `ConnectionInfo`
* Added `Box` to the `AwsErr` trait to keep clippy from warning about large variants
* Reworked how we extract the secret data to better handle multiple secrets if we wish to add more in the future.
* Added helper functions to better handle data type conversion from the Kubernetes Secret to create `ConnectionInfo`

fixes: [TEM-1389](https://linear.app/tembo/issue/TEM-1389/add-connection-strings-for-app-user)