### PR TITLE
fix how we return connection string info

### DIFF
--- a/conductor/src/errors.rs
+++ b/conductor/src/errors.rs
@@ -39,4 +39,7 @@ pub enum ConductorError {
 
     #[error("Failed to parse postgres connection information")]
     ParsingPostgresConnectionError,
+
+    #[error("Secret data not found for: {0}")]
+    SecretDataNotFound(String),
 }


### PR DESCRIPTION
This PR should fix the issue where we see weird/non-standard connection string data in the UI.

I believe the data that was being rendered with this logic was causing the issue.

```
    match data.get(field) {
        Some(k8s_openapi::ByteString(vec)) => {
            let string_data = std::str::from_utf8(vec)
                .map_err(|_| ConductorError::ParsingPostgresConnectionError)?;
            Ok(string_data.to_string())
        }
        None => Err(ConductorError::PostgresConnectionInfoNotFound),
    }
}
```

* Simplify how we get the username and password.
* Write a test for the `get_field_value_from_secret` function to make sure the data we parse is valid.