### PR TITLE
Don't wait for extensions to finish in an Update event

### DIFF
--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -338,12 +338,12 @@ async fn run(metrics: CustomMetrics) -> Result<(), Box<dyn std::error::Error>> {
 
                 let result = get_one(client.clone(), &namespace).await;
 
-                let requeue = match &result {
+                let extension_still_processing = match &result {
                     Ok(coredb) => extensions_still_processing(coredb),
                     Err(_) => true,
                 };
 
-                if requeue {
+                if extension_still_processing && read_msg.message.event_type == Event::Create {
                     let _ = queue
                         .set_vt::<CRUDevent>(
                             &control_plane_events_queue,

--- a/conductor/src/types.rs
+++ b/conductor/src/types.rs
@@ -14,7 +14,7 @@ pub struct CRUDevent {
     pub spec: Option<CoreDBSpec>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum Event {
     Create,
     Created,

--- a/conductor/testdata/operator-values.yaml
+++ b/conductor/testdata/operator-values.yaml
@@ -1,8 +1,5 @@
 image:
-  # This to get tests of conductor to use
-  # new version of operator.
-  # Delete this after merge.
-  tag: 7d5f1e1
+  tag: latest
 env:
   - name: ENABLE_INITIAL_BACKUP
     value: "false"


### PR DESCRIPTION
If you have a cluster and click a lot of extension installs or toggles, then you delete your cluster, there could be a situation where an update event comes in after the delete event since we requeue the update event when extensions are still processing. There is no need to requeue, we can just return the current status, and the ad-hoc updates will return the extensions status as they become available. Still, we can wait for all extensions to be ready during Create, so that clusters go from Submitted to Created only after all initially requested extensions are ready.
