### PR TITLE
Local dev updates, Helm chart updates

### DIFF
--- a/charts/tembo-pod-init/templates/self-signed-certs.yaml
+++ b/charts/tembo-pod-init/templates/self-signed-certs.yaml
@@ -27,4 +27,5 @@ spec:
   issuerRef:
     name: {{ printf "%s-issuer" (include "tembo-pod-init.fullname" .) }}
   secretName: {{ printf "%s-tls" (include "tembo-pod-init.fullname" .) }}
-
+  privateKey:
+    rotationPolicy: Always

--- a/tembo-pod-init/justfile
+++ b/tembo-pod-init/justfile
@@ -1,6 +1,7 @@
+# vim: set ft=make :
 NAME := "tembo-pod-init"
 #VERSION := `git rev-parse HEAD`
-CERT_MANAGER_VERSION := "v1.12.1"
+CERT_MANAGER_VERSION := "v1.12.3"
 SEMVER_VERSION := `grep version Cargo.toml | awk -F"\"" '{print $2}' | head -n 1`
 NAMESPACE := "default"
 KUBE_VERSION := "1.26"
@@ -10,28 +11,70 @@ ENV := "development"
 default:
   @just --list --unsorted --color=always | rg -v "    default"
 
-# delete kind
-delete-kind:
-	kind delete cluster && sleep 5
-
-# start kind
-start-kind:
-  scripts/start-kind-with-registry.sh
-  kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
-
 # install cert-manager
 cert-manager:
   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/{{CERT_MANAGER_VERSION}}/cert-manager.yaml
   sleep 7
   kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
 
-# install cnpg
-cnpg:
-  kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.20/releases/cnpg-1.20.0.yaml
-  kubectl apply -f testdata/cnpg-cm.yaml 
-  sleep 7
-  kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
-  kubectl rollout restart -n cnpg-system deployment cnpg-controller-manager
+install-reloader:
+	kubectl create namespace reloader || true
+	helm upgrade --install --namespace=reloader reloader stakater/reloader --values ./testdata/reloader.yaml
+
+install-kube-prometheus-stack:
+	kubectl create namespace monitoring || true
+	helm upgrade --install --namespace=monitoring monitoring prometheus-community/kube-prometheus-stack
+
+
+install-tembo-pod-init:
+	kubectl create namespace tembo-pod-init || true
+	helm upgrade --install --namespace=tembo-pod-init --values=./testdata/pod-init.yaml tembo-pod-init ../charts/tembo-pod-init
+
+install-cnpg:
+	helm upgrade --install cnpg \
+	 --namespace cnpg-system \
+	 --create-namespace \
+		--values=./testdata/cnpg.yaml \
+	 cnpg/cloudnative-pg
+
+install-tempo:
+	helm upgrade --install \
+		tempo grafana/tempo \
+	 --namespace monitoring
+
+enable-cnpg-default-namespace:
+	kubectl label namespace default "tembo-pod-init.tembo.io/watch"="true"
+	kubectl delete pods -n tembo-pod-init --all
+
+update-helm-repos:
+	helm repo add cnpg https://cloudnative-pg.github.io/charts
+	helm repo add jetstack https://charts.jetstack.io
+	helm repo add traefik https://traefik.github.io/charts
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+	helm repo add grafana https://grafana.github.io/helm-charts
+	helm repo add stakater https://stakater.github.io/stakater-charts
+	helm repo update
+
+install-operator:
+  kubectl apply -f ../charts/tembo-operator/templates/crd.yaml
+  helm upgrade --install --create-namespace --namespace=coredb-operator --values=./testdata/operator-values.yaml tembo-operator ../charts/tembo-operator 
+
+# delete kind
+delete-kind:
+	kind delete cluster && sleep 5
+
+# start kind
+start-kind:
+	kind delete cluster || true
+	scripts/start-kind-with-registry.sh
+	just update-helm-repos
+	just cert-manager
+	just install-reloader
+	just install-kube-prometheus-stack
+	just install-tempo
+	just install-cnpg
+	just enable-cnpg-default-namespace
+	kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
 
 # run
 run:

--- a/tembo-pod-init/testdata/cnpg.yaml
+++ b/tembo-pod-init/testdata/cnpg.yaml
@@ -1,0 +1,10 @@
+config:
+  data:
+    INHERITED_ANNOTATIONS: tembo-pod-init.tembo.io/*
+resources:
+  limits:
+    cpu: 100m
+    memory: 200Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi

--- a/tembo-pod-init/testdata/operator-values.yaml
+++ b/tembo-pod-init/testdata/operator-values.yaml
@@ -1,0 +1,12 @@
+image:
+  # This to get tests of conductor to use
+  # new version of operator.
+  # Delete this after merge.
+  tag: latest
+env:
+  - name: ENABLE_INITIAL_BACKUP
+    value: "false"
+  - name: RUST_LOG
+    value: debug,kube=debug,controller=debug
+  - name: OPENTELEMETRY_ENDPOINT_URL
+    value: http://tempo.monitoring.svc.cluster.local:4317

--- a/tembo-pod-init/testdata/pod-init.yaml
+++ b/tembo-pod-init/testdata/pod-init.yaml
@@ -1,0 +1,18 @@
+image:
+  tag: latest
+extraEnv:
+  - name: OPENTELEMETRY_ENDPOINT_URL
+    value: http://tempo.monitoring.svc.cluster.local:4317
+  - name: RUST_LOG
+    value: debug
+  - name: ENV
+    value: development
+resources:
+  requests:
+    cpu: 50m
+    memory: 100Mi
+  limits:
+    cpu: 200m
+    memory: 300Mi
+annotations:
+  reloader.stakater.com/auto: "true"

--- a/tembo-pod-init/testdata/reloader.yaml
+++ b/tembo-pod-init/testdata/reloader.yaml
@@ -1,0 +1,3 @@
+reloader:
+  podMonitor:
+    enabled: true


### PR DESCRIPTION
* Update `justfile` to have better support for local development
* Update the helm chart self-signed certificate template to set `rotationPolicy: Always`.  You can read more about this setting [here](https://cert-manager.io/docs/usage/certificate/#the-rotationpolicy-setting)

fixes: [TEM-1600](https://linear.app/tembo/issue/TEM-1600/issue-with-renewing-certs-with-pod-init)