### PR TITLE
Use `standard-cnpg` image in Standard Stack

### DIFF
--- a/stacks/standard.yaml
+++ b/stacks/standard.yaml
@@ -1,6 +1,6 @@
 name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/tembo-pg-cnpg:15.3.0-5-cede445"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-d6f9ddd"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 1


### PR DESCRIPTION
Replace `tembo-pg-cnpg` image with `standard-cnpg` image.