### PR TITLE
Bump to standard-cnpg:15.3.0-1-0c19c7e

### DIFF
--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -83,7 +83,7 @@ spec:
                   type: object
                 type: array
               image:
-                default: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e
+                default: quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e
                 type: string
               metrics:
                 nullable: true

--- a/stacks/machine_learning.yaml
+++ b/stacks/machine_learning.yaml
@@ -1,6 +1,6 @@
 name: MachineLearning
 description: A Postgres instance equipped with machine learning extensions and optimized for machine learning workloads.
-image: "quay.io/tembo/ml-cnpg:15.3.0-1-ac943a8"
+image: "quay.io/tembo/ml-cnpg:15.3.0-1-63e32a1"
 stack_version: 0.3.0
 compute_templates:
   - cpu: 2

--- a/stacks/message_queue.yaml
+++ b/stacks/message_queue.yaml
@@ -1,6 +1,6 @@
 name: MessageQueue
 description: A Tembo Postgres Stack optimized for Message Queue workloads.
-image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-cede445
+image: quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e
 stack_version: 0.2.0
 compute_templates:
   - cpu: 1

--- a/stacks/olap.yaml
+++ b/stacks/olap.yaml
@@ -1,6 +1,6 @@
 name: OLAP
 description: A Postgres instance equipped with configuration and extensions for OLAP workloads.
-image: "quay.io/tembo/tembo-pg-cnpg:15.3.0-5-cede445"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 1

--- a/stacks/oltp.yaml
+++ b/stacks/oltp.yaml
@@ -1,6 +1,6 @@
 name: OLTP
 description: A Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/tembo-pg-cnpg:15.3.0-5-cede445"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 1

--- a/stacks/standard.yaml
+++ b/stacks/standard.yaml
@@ -1,6 +1,6 @@
 name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-d6f9ddd"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 1

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -42,7 +42,7 @@ pub fn default_image() -> String {
 }
 
 pub fn default_llm_image() -> String {
-    "quay.io/tembo/ml-cnpg:15.3.0-1-77fcafc".to_owned()
+    "quay.io/tembo/ml-cnpg:15.3.0-1-63e32a1".to_owned()
 }
 
 pub fn default_storage() -> Quantity {

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -38,7 +38,7 @@ pub fn default_port() -> i32 {
 }
 
 pub fn default_image() -> String {
-    "quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e".to_owned()
+    "quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e".to_owned()
 }
 
 pub fn default_llm_image() -> String {


### PR DESCRIPTION
Bump image to `standard-cnpg:15.3.0-1-0c19c7e` in the following stacks:
- `Standard`
- `MessageQueue`
- `OLAP`
- `OLTP`