### PR TITLE
Avoid bursts of reconciliation

### DIFF
--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -49,6 +49,7 @@ itertools = "0.11.0"
 base64 = "0.21.2"
 semver = "1.0.18"
 anyhow = "1.0.72"
+rand = "0.8.5"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -34,6 +34,7 @@ use crate::{
     extensions::reconcile_extensions,
     postgres_exporter::{create_postgres_exporter_role, reconcile_prom_configmap},
 };
+use rand::Rng;
 use serde::Serialize;
 use serde_json::json;
 use std::sync::Arc;
@@ -266,8 +267,8 @@ impl CoreDB {
         patch_cdb_status_merge(&coredbs, &name, patch_status).await?;
 
         info!("Fully reconciled {}", self.name_any());
-        // Check back every minute
-        Ok(Action::requeue(Duration::from_secs(60)))
+        let jitter = rand::thread_rng().gen_range(0..30);
+        Ok(Action::requeue(Duration::from_secs(60 + jitter)))
     }
 
     // Finalizer cleanup (the object was deleted, ensure nothing is orphaned)


### PR DESCRIPTION
Small change, I noticed sometimes we get updates from control plane all at once, this results in the extensions always reconciling in bursts, which just made things slightly slower