### PR TITLE
Auto-enable libraries for extensions that require load

### DIFF
--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -16,7 +16,9 @@ use kube::CustomResource;
 use crate::extensions::types::{Extension, TrunkInstall, TrunkInstallStatus};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use crate::apis::postgres_parameters::ConfigValue;
+use crate::extensions::toggle::REQUIRES_LOAD;
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
 pub struct ServiceAccountTemplate {
@@ -108,11 +110,48 @@ impl CoreDBSpec {
             .as_ref()
             .and_then(|s| s.postgres_config.clone())
             .unwrap_or_default();
-        let runtime_configs = self.runtime_config.clone().unwrap_or_default();
+        let mut runtime_configs = self.runtime_config.clone().unwrap_or_default();
         // TODO: configs that come with extension installation
         // e.g. let extension_configs = ...
         // these extensions could be set by the operator, or trunk + operator
         // trunk install pg_partman could come with something like `pg_partman_bgw.dbname = xxx`
+
+        // Get list of extension names that require load
+        let mut requires_load = BTreeSet::new();
+        for ext in self.extensions.iter() {
+            if REQUIRES_LOAD.contains(&ext.name.as_str()) {
+                requires_load.insert(ext.name.clone());
+            }
+        }
+
+        let shared_preload_from_extensions = ConfigValue::Multiple(requires_load);
+        let extension_settings_config = vec![PgConfig {
+            name: "shared_preload_libraries".to_string(),
+            value: shared_preload_from_extensions,
+        }];
+
+        match merge_pg_configs(
+            &runtime_configs,
+            &extension_settings_config,
+            "shared_preload_libraries",
+        )? {
+            None => {}
+            Some(new_shared_preload_libraries) => {
+                // check by name attribute if runtime_configs already has shared_preload_libraries
+                // if so replace the value. Otherwise add this PgConfig into the vector.
+                let mut found = false;
+                for cfg in &mut runtime_configs {
+                    if cfg.name == "shared_preload_libraries" {
+                        cfg.value = new_shared_preload_libraries.value.clone();
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    runtime_configs.push(new_shared_preload_libraries);
+                }
+            }
+        }
 
         // handle merge of any of the settings that are multi-value.
         // e.g. stack defines shared_preload_libraries = pg_cron, then operator installs pg_stat_statements at runtime

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -118,11 +118,11 @@ impl CoreDBSpec {
 
         // Get list of extension names that require load
         let mut requires_load = BTreeSet::new();
-        'ext: for ext in self.extensions.iter() {
-            for location in ext.locations.iter() {
+        for ext in self.extensions.iter() {
+            'loc: for location in ext.locations.iter() {
                 if location.clone().enabled && REQUIRES_LOAD.contains(&ext.name.as_str()) {
                     requires_load.insert(ext.name.clone());
-                    break 'ext;
+                    break 'loc;
                 }
             }
         }

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -13,12 +13,16 @@ use crate::{
 };
 use kube::CustomResource;
 
-use crate::extensions::types::{Extension, TrunkInstall, TrunkInstallStatus};
+use crate::{
+    apis::postgres_parameters::ConfigValue,
+    extensions::{
+        toggle::REQUIRES_LOAD,
+        types::{Extension, TrunkInstall, TrunkInstallStatus},
+    },
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use crate::apis::postgres_parameters::ConfigValue;
-use crate::extensions::toggle::REQUIRES_LOAD;
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
 pub struct ServiceAccountTemplate {

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -118,9 +118,12 @@ impl CoreDBSpec {
 
         // Get list of extension names that require load
         let mut requires_load = BTreeSet::new();
-        for ext in self.extensions.iter() {
-            if REQUIRES_LOAD.contains(&ext.name.as_str()) {
-                requires_load.insert(ext.name.clone());
+        'ext: for ext in self.extensions.iter() {
+            for location in ext.locations.iter() {
+                if location.clone().enabled && REQUIRES_LOAD.contains(&ext.name.as_str()) {
+                    requires_load.insert(ext.name.clone());
+                    break 'ext;
+                }
             }
         }
 

--- a/tembo-operator/src/apis/postgres_parameters.rs
+++ b/tembo-operator/src/apis/postgres_parameters.rs
@@ -22,7 +22,9 @@ pub const MULTI_VAL_CONFIGS: [&str; 5] = [
 ];
 
 // This array defines the priority order for any multi-value config
-pub const MULTI_VAL_CONFIGS_PRIORITY_LIST: [&str; 2] = ["pg_stat_statements", "pg_stat_kcache"];
+// This defines any required order for shared_preload_libraries, otherwise alphabetical
+// TODO: move this to a trunk endpoint
+pub const MULTI_VAL_CONFIGS_PRIORITY_LIST: [&str; 3] = ["citus", "pg_stat_statements", "pg_stat_kcache"];
 
 // configurations that are not allowed to be set by the user
 pub const DISALLOWED_CONFIGS: [&str; 66] = [

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1735,4 +1735,137 @@ mod test {
         // Delete namespace
         let _ = delete_namespace(client.clone(), &namespace).await;
     }
+
+    #[tokio::test]
+    #[ignore]
+    async fn functional_test_shared_preload_libraries() {
+        // Initialize the Kubernetes client
+        let client = kube_client().await;
+        let state = State::default();
+        let context = state.create_context(client.clone());
+
+        // Configurations
+        let mut rng = rand::thread_rng();
+        let suffix = rng.gen_range(0..100000);
+        let name = &format!("test-requires-load-{}", suffix);
+        let namespace = match create_namespace(client.clone(), name).await {
+            Ok(namespace) => namespace,
+            Err(e) => {
+                eprintln!("Error creating namespace: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        let kind = "CoreDB";
+        let replicas = 1;
+
+        // Create a pod we can use to run commands in the cluster
+        let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+
+        // Apply a basic configuration of CoreDB
+        println!("Creating CoreDB resource {}", name);
+        let coredbs: Api<CoreDB> = Api::namespaced(client.clone(), &namespace);
+        // Generate basic CoreDB resource to start with
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "replicas": replicas,
+                "extensions": [{
+                        "name": "pg_cron",
+                        "description": "cron",
+                        "locations": [{
+                            "enabled": true,
+                            "version": "1.5.2",
+                            "database": "postgres",
+                        }],
+                    },
+                    {
+                        "name": "citus",
+                        "description": "citus",
+                        "locations": [{
+                            "enabled": true,
+                            "version": "12.0.1",
+                            "database": "postgres",
+                        }],
+                }],
+                "trunk_installs": [{
+                        "name": "pg_cron",
+                        "version": "1.5.2",
+                },
+                {
+                        "name": "citus",
+                        "version": "12.0.1",
+                }]
+            }
+        });
+        let params = PatchParams::apply("tembo-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        // Wait for CNPG Pod to be created
+        let pod_name = format!("{}-1", name);
+
+        pod_ready_and_running(pods.clone(), pod_name.clone()).await;
+
+        let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+        let lp =
+            ListParams::default().labels(format!("app=postgres-exporter,coredb.io/name={}", name).as_str());
+        let exporter_pods = pods.list(&lp).await.expect("could not get pods");
+        let exporter_pod_name = exporter_pods.items[0].metadata.name.as_ref().unwrap();
+        println!("Exporter pod name: {}", &exporter_pod_name);
+
+        pod_ready_and_running(pods.clone(), exporter_pod_name.clone()).await;
+
+        // Assert that we can query the database with \dt;
+        let result = coredb_resource
+            .psql("\\dt".to_string(), "postgres".to_string(), context.clone())
+            .await
+            .unwrap();
+        println!("psql out: {}", result.stdout.clone().unwrap());
+        assert!(!result.stdout.clone().unwrap().contains("postgres"));
+
+        let coredb_resource = coredbs.get(name).await.unwrap();
+        let mut found_citus = false;
+        let mut found_cron = false;
+        for extension in coredb_resource.status.unwrap().extensions.unwrap() {
+            for location in extension.locations {
+                if extension.name == "citus" && location.enabled.unwrap() {
+                    found_citus = true;
+                    assert!(location.database == "postgres");
+                    assert!(location.schema.clone().unwrap() == "pg_catalog");
+                }
+                if extension.name == "pg_cron" && location.enabled.unwrap() {
+                    found_cron = true;
+                    assert!(location.database == "postgres");
+                    assert!(location.schema.unwrap() == "pg_catalog");
+                }
+            }
+        }
+        assert!(found_citus);
+        assert!(found_cron);
+
+        // CLEANUP TEST
+        // Cleanup CoreDB
+        coredbs.delete(name, &Default::default()).await.unwrap();
+        println!("Waiting for CoreDB to be deleted: {}", &name);
+        let _assert_coredb_deleted = tokio::time::timeout(
+            Duration::from_secs(TIMEOUT_SECONDS_COREDB_DELETED),
+            await_condition(coredbs.clone(), name, conditions::is_deleted("")),
+        )
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "CoreDB {} was not deleted after waiting {} seconds",
+                    name, TIMEOUT_SECONDS_COREDB_DELETED
+                )
+            });
+        println!("CoreDB resource deleted {}", name);
+
+        // Delete namespace
+        let _ = delete_namespace(client.clone(), &namespace).await;
+    }
 }

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1856,13 +1856,13 @@ mod test {
             Duration::from_secs(TIMEOUT_SECONDS_COREDB_DELETED),
             await_condition(coredbs.clone(), name, conditions::is_deleted("")),
         )
-            .await
-            .unwrap_or_else(|_| {
-                panic!(
-                    "CoreDB {} was not deleted after waiting {} seconds",
-                    name, TIMEOUT_SECONDS_COREDB_DELETED
-                )
-            });
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "CoreDB {} was not deleted after waiting {} seconds",
+                name, TIMEOUT_SECONDS_COREDB_DELETED
+            )
+        });
         println!("CoreDB resource deleted {}", name);
 
         // Delete namespace


### PR DESCRIPTION
This PR covers extensions that require load and require create extension, but not extensions that require load and not create extension.

Allows enabling these extensions
```
citus
pg_cron
pg_later
pglogical
pglogical_ticker
pg_net
pg_tle
plrust
timescaledb
```