### PR TITLE
add action and workflow to publish controller

### DIFF
--- a/.github/actions/find-changed-directories/action.yml
+++ b/.github/actions/find-changed-directories/action.yml
@@ -1,0 +1,53 @@
+name: 'Find changed directories'
+description: 'Finds directories containing a specific filename in the root of that directory, filtering out directories that are unchanged relative to a given branch name'
+inputs:
+  contains_the_file:
+    description: 'Look for directories with this file in the root of that directory. For example, Dockerfile or Cargo.toml'
+    required: true
+  fetch_branch_to_compare:
+    description: 'The branch to fetch when looking to compare a ref, typically main'
+    default: "main"
+    required: true
+  changed_relative_to_ref:
+    description: 'The ref on the fetched branch to compare with to determine if this directory has changed. For example "origin/main" or a git commit hash.'
+    required: true
+  ignore_dirs:
+    description: A list of directories to ignore.
+    required: false
+    default: ''
+outputs:
+  build_matrix:
+    description: "Input this output to your matrix build in a following job, like this 'fromJson(needs.find_directories.outputs.build_matrix)'"
+    value: ${{ steps.find_directories.outputs.build_matrix }}
+runs:
+  using: "composite"
+  steps:
+    - name: Find directories with a given file name
+      shell: bash
+      id: find_directories
+      run: |
+        set -xe
+        git fetch origin ${{ inputs.fetch_branch_to_compare }} || true
+        # Get directories with a Dockerfile that have not changed
+        # relative to the branch we are pulling into
+        echo "${{inputs.ignore_dirs}}"
+        IFS=', ' read -r -a array <<< "${{inputs.ignore_dirs}}"
+        EXCLUDE_OPTS=()
+        for exclude_dir in "${array[@]}"; do
+          EXCLUDE_OPTS+=("-not" "-path" "*/$exclude_dir/*")
+        done
+        directories=$(
+        find . -name ${{ inputs.contains_the_file }} -not -path "*/target/*" -not -path "*/.github/*" "${EXCLUDE_OPTS[@]}" -exec dirname {} \; | while read dir; do
+          # This will check if the directory has changed relative to the branch we are PRing
+          # into, and if it's not a PR, in the case of main or release/**, then it will
+          # build all docker directories
+          if git diff --quiet HEAD ${{ inputs.changed_relative_to_ref }} -- "$dir"; then
+            echo ""
+          else
+            echo "$dir"
+          fi
+        done)
+        # Format directories into a build matrix
+        matrix_include=$(echo "${directories}" | awk 'NF{print $NF};' | while read dir; do dir_without_dot=$(basename ${dir}); echo "{\"path\": \"$dir\", \"name\": \"$dir_without_dot\"}"; done | jq -scM '{"include": .}')
+        echo "${matrix_include}"
+        echo "build_matrix=${matrix_include}" >> $GITHUB_OUTPUT

--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -1,0 +1,79 @@
+name: 'Publish to crates.io'
+description: 'Publish cratest to crates.io and some other crates.io-related actions, like checking if a version is already published.'
+inputs:
+  working-directory:
+    required: false
+    description: "In which directory should we run 'cargo publish'?"
+    default: "."
+  cargo-registry-token:
+    required: true
+    description: "The CARGO_REGISTRY_TOKEN to use"
+  fail-if-version-published:
+    description: "If the version is already published, should we fail, or ignore? By default, ignore."
+    required: false
+    default: false
+  dry-run:
+    description: "Use --dry-run flag on cargo publish?"
+    required: false
+    default: false
+  toolchain:
+    description: "Which Rust toolchain to use?"
+    default: "stable"
+    required: false
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ inputs.toolchain }}
+    - name: Install TOML parser
+      shell: bash
+      run: |
+       set -xe
+       wget https://github.com/freshautomations/stoml/releases/download/v0.7.1/stoml_linux_amd64 &> /dev/null
+       mv stoml_linux_amd64 stoml
+       chmod +x stoml
+       sudo mv stoml /usr/local/bin/
+    - name: Publish
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -xe
+
+        # If package.publish is false, skip the rest
+        SHOULD_PUBLISH=$(stoml Cargo.toml package.publish)
+        if [[ "${SHOULD_PUBLISH}" == "false" ]]; then
+            echo "Found package.publish is false. Skipping."
+            exit 0
+        fi
+
+        # Get crate information
+        NAME=$(stoml Cargo.toml package.name)
+        VERSION=$(stoml Cargo.toml package.version)
+        VERSIONS_INFO=$(curl https://crates.io/api/v1/crates/${NAME} 2> /dev/null)
+        # "|| true" handles the case where this crate hasn't yet been published
+        PUBLISHED_VERSIONS=$(echo ${VERSIONS_INFO} | jq -r '.versions[] | .num' || true)
+        echo ${VERSIONS_INFO}
+
+        # If this version is already published...
+        if echo ${VERSIONS_INFO} | jq -r ".versions[] | .num | . == \"${VERSION}\"" | grep true; then
+          echo "The version '${VERSION}' of '${NAME}' is already published."
+          if [ "${{ inputs.fail-if-version-published }}" == "true" ]; then
+            exit 1
+          else
+            echo "Skipping the rest of the action because inputs.fail-if-version-published is false."
+            exit 0
+          fi
+        fi
+        echo "Did not detect the version ${VERSION} to be already published."
+        echo "The list of known versions:"
+        echo $PUBLISHED_VERSIONS
+
+        # Set --dry-run flag, if configured
+        DRY_RUN=""
+        if [ "${{ inputs.dry-run }}" == "true" ]; then
+          DRY_RUN="--dry-run"
+        fi
+
+        cargo publish ${DRY_RUN} --token ${{ inputs.cargo-registry-token }}

--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -1,0 +1,76 @@
+name: Cargo publish or validate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  find_directories:
+    name: Find crates that changed
+    runs-on: ubuntu-20.04
+    outputs:
+      changed_crates: ${{ steps.find_directories.outputs.build_matrix }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Find directories including Cargo.toml that changed
+        id: find_directories
+        uses: ./.github/actions/find-changed-directories
+        with:
+          contains_the_file: Cargo.toml
+          # If the branch does not exist, then it will not
+          # filter any directories containing the file.
+          # This allows for filtering out unchanged directories
+          # in a pull request, and using all directories on the release
+          # or main branches.
+          changed_relative_to_ref: origin/${{ github.base_ref || 'not-a-branch' }}
+
+
+  cargo_publish:
+    # On a pull request, this is validating that the version
+    # is not already published to crates.io, and on a push to
+    # main or release branches, it is publishing if the version
+    # does not exist, ignoring if the version is already
+    # published.
+    name: Cargo publish or validate
+    runs-on: ubuntu-20.04
+    needs:
+      - find_directories
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_directories.outputs.changed_crates) }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Determine which flags to use on cargo publish
+        id: cargo_flags
+        run: |
+          set -x
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          if [ "${BRANCH_NAME}" == "main" ]; then
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+            echo "fail_if_version_published=false" >> $GITHUB_OUTPUT
+          elif [[ "${BRANCH_NAME}" == release/* ]]; then
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+            echo "fail_if_version_published=false" >> $GITHUB_OUTPUT
+          else
+            echo "dry_run=true" >> $GITHUB_OUTPUT
+            echo "fail_if_version_published=true" >> $GITHUB_OUTPUT
+          fi
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ matrix.name }}
+          workspaces: |
+            ${{ matrix.path }}
+      - name: Publish or validate
+        uses: ./.github/actions/publish-crate
+        with:
+          working-directory: ${{ matrix.path }}
+          dry-run: ${{ steps.cargo_flags.outputs.dry_run }}
+          fail-if-version-published: ${{ steps.cargo_flags.outputs.fail_if_version_published }}
+          cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "conductor"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-pod-init/Cargo.toml
+++ b/tembo-pod-init/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tembo-pod-init"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [[bin]]
 doc = false


### PR DESCRIPTION
The workflow should identify any crate in the repo, so setting every Cargo.toml to `publish = false` except for the tembo-operator.