### PR TITLE
replace coredb Stack w/ Stacks def

### DIFF
--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -317,6 +317,72 @@ spec:
               stack:
                 nullable: true
                 properties:
+                  compute_templates:
+                    items:
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                      required:
+                      - cpu
+                      - memory
+                      type: object
+                    nullable: true
+                    type: array
+                  description:
+                    nullable: true
+                    type: string
+                  extensions:
+                    items:
+                      properties:
+                        description:
+                          default: No description provided
+                          nullable: true
+                          type: string
+                        locations:
+                          items:
+                            properties:
+                              database:
+                                default: postgres
+                                type: string
+                              enabled:
+                                type: boolean
+                              schema:
+                                nullable: true
+                                type: string
+                              version:
+                                nullable: true
+                                type: string
+                            required:
+                            - enabled
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                      required:
+                      - locations
+                      - name
+                      type: object
+                    nullable: true
+                    type: array
+                  image:
+                    default: quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e
+                    nullable: true
+                    type: string
+                  infrastructure:
+                    nullable: true
+                    properties:
+                      cpu:
+                        default: '1'
+                        type: string
+                      memory:
+                        default: 1Gi
+                        type: string
+                      storage:
+                        default: 10Gi
+                        type: string
+                    type: object
                   name:
                     type: string
                   postgres_config:
@@ -330,6 +396,54 @@ spec:
                       required:
                       - name
                       - value
+                      type: object
+                    nullable: true
+                    type: array
+                  postgres_config_engine:
+                    default: standard
+                    enum:
+                    - standard
+                    - olap
+                    nullable: true
+                    type: string
+                  postgres_metrics:
+                    nullable: true
+                    type: object
+                  services:
+                    items:
+                      properties:
+                        command:
+                          type: string
+                        config: {}
+                        image:
+                          type: string
+                        ports:
+                          items:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type: array
+                      required:
+                      - command
+                      - config
+                      - image
+                      - ports
+                      type: object
+                    nullable: true
+                    type: array
+                  stack_version:
+                    nullable: true
+                    type: string
+                  trunk_installs:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          nullable: true
+                          type: string
+                      required:
+                      - name
                       type: object
                     nullable: true
                     type: array

--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -414,7 +414,6 @@ spec:
                       properties:
                         command:
                           type: string
-                        config: {}
                         image:
                           type: string
                         ports:
@@ -425,7 +424,6 @@ spec:
                           type: array
                       required:
                       - command
-                      - config
                       - image
                       - ports
                       type: object

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -1,4 +1,4 @@
-use crate::extensions::types::ExtensionStatus;
+use crate::{extensions::types::ExtensionStatus, stacks::types::Stack};
 use k8s_openapi::{
     api::core::v1::ResourceRequirements,
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
@@ -234,13 +234,6 @@ pub struct CoreDBStatus {
     pub runtime_config: Option<Vec<PgConfig>>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct Stack {
-    pub name: String,
-    // static configs defined in the tembo stack
-    pub postgres_config: Option<Vec<PgConfig>>,
-    // TODO: add other stack attributes as they are supported
-}
 
 #[cfg(test)]
 mod tests {

--- a/tembo-operator/src/apis/postgres_parameters.rs
+++ b/tembo-operator/src/apis/postgres_parameters.rs
@@ -377,7 +377,7 @@ impl<'de> Deserialize<'de> for PgConfig {
 #[cfg(test)]
 mod pg_param_tests {
     use super::*;
-    use crate::apis::coredb_types::{CoreDBSpec, Stack};
+    use crate::{apis::coredb_types::CoreDBSpec, stacks::types::Stack};
 
     #[test]
     fn test_pg_config() {
@@ -429,6 +429,7 @@ mod pg_param_tests {
                         value: "yolo".parse().unwrap(),
                     },
                 ]),
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -1,6 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, default};
+use std::collections::BTreeMap;
 use utoipa::ToSchema;
 
 use crate::{
@@ -10,12 +10,6 @@ use crate::{
     postgres_exporter::QueryConfig,
     stacks::config_engines::{olap_config_engine, standard_config_engine, ConfigEngine},
 };
-
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct StackLeg {
-    pub name: StackType,
-    pub postgres_config: Option<Vec<PgConfig>>,
-}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub enum StackType {

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -126,7 +126,6 @@ pub struct Service {
     pub image: String,
     pub command: String,
     pub ports: Vec<BTreeMap<String, String>>,
-    pub config: serde_json::Value,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use the Stacks struct from the `Stacks` API instead of coredb types, which requires update to the crd. It is a non-breaking change because all the new attributes on `Stack` are optional.