### PR TITLE
[tembo-operator] Add instance restore capabilities into operator

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -74,7 +74,6 @@ jobs:
       - name: Run functional / integration tests
         run: |
           set -xe
-          export ENABLE_BACKUP=false
           export DATA_PLANE_BASEDOMAIN=localhost
           # Start the operator in the background
           cargo run > operator-output.txt 2>&1 &

--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -125,22 +125,77 @@ spec:
               backup:
                 default:
                   destinationPath: s3://
-                  encryption: AES256
+                  encryption: null
                   retentionPolicy: '30'
                   schedule: 0 0 * * *
+                  endpointURL: null
+                  s3Credentials: null
                 properties:
                   destinationPath:
                     default: s3://
                     nullable: true
                     type: string
                   encryption:
-                    default: AES256
+                    nullable: true
+                    type: string
+                  endpointURL:
                     nullable: true
                     type: string
                   retentionPolicy:
                     default: '30'
                     nullable: true
                     type: string
+                  s3Credentials:
+                    nullable: true
+                    properties:
+                      accessKeyId:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      inheritFromIAMRole:
+                        nullable: true
+                        type: boolean
+                      region:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      secretAccessKey:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sessionToken:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
                   schedule:
                     default: 0 0 * * *
                     nullable: true
@@ -254,6 +309,71 @@ spec:
                       type: string
                     description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
+                type: object
+              restore:
+                nullable: true
+                properties:
+                  endpointURL:
+                    nullable: true
+                    type: string
+                  recoveryTargetTime:
+                    nullable: true
+                    type: string
+                  s3Credentials:
+                    nullable: true
+                    properties:
+                      accessKeyId:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      inheritFromIAMRole:
+                        nullable: true
+                        type: boolean
+                      region:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      secretAccessKey:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      sessionToken:
+                        nullable: true
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    type: object
+                  serverName:
+                    type: string
+                required:
+                - serverName
                 type: object
               runtime_config:
                 items:

--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -125,17 +125,19 @@ spec:
               backup:
                 default:
                   destinationPath: s3://
-                  encryption: null
+                  encryption: AES256
                   retentionPolicy: '30'
                   schedule: 0 0 * * *
                   endpointURL: null
-                  s3Credentials: null
+                  s3Credentials:
+                    inheritFromIAMRole: true
                 properties:
                   destinationPath:
                     default: s3://
                     nullable: true
                     type: string
                   encryption:
+                    default: AES256
                     nullable: true
                     type: string
                   endpointURL:
@@ -146,6 +148,8 @@ spec:
                     nullable: true
                     type: string
                   s3Credentials:
+                    default:
+                      inheritFromIAMRole: true
                     nullable: true
                     properties:
                       accessKeyId:

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -9,7 +9,7 @@ use conductor::{
     get_coredb_error_without_status, get_one, get_pg_conn, lookup_role_arn, parse_event_id,
     restart_cnpg, restart_statefulset, types,
 };
-use controller::apis::coredb_types::{Backup, CoreDBSpec, ServiceAccountTemplate};
+use controller::apis::coredb_types::{Backup, CoreDBSpec, S3Credentials, ServiceAccountTemplate};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::Client;
 use log::{debug, error, info, warn};
@@ -242,6 +242,10 @@ async fn run(metrics: CustomMetrics) -> Result<(), Box<dyn std::error::Error>> {
                     encryption: Some(String::from("AES256")),
                     retentionPolicy: Some(String::from("30")),
                     schedule: Some(generate_rand_schedule().await),
+                    s3_credentials: Some(S3Credentials {
+                        inherit_from_iam_role: Some(true),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 };
 

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -242,6 +242,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), Box<dyn std::error::Error>> {
                     encryption: Some(String::from("AES256")),
                     retentionPolicy: Some(String::from("30")),
                     schedule: Some(generate_rand_schedule().await),
+                    ..Default::default()
                 };
 
                 // Merge backup and service_account_template into spec

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "base64 0.21.4",
  "chrono",
  "futures",
+ "futures-util",
  "http",
  "hyper",
  "itertools 0.11.0",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -60,6 +60,7 @@ http = "0.2.9"
 hyper = "0.14.27"
 rand = "0.8.5"
 tower-test = "0.4.0"
+futures-util = "0.3"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive", "ws"]

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -48,7 +48,7 @@ install-minio:
 	  --namespace minio \
 		--create-namespace \
 		--values=./testdata/minio.yaml \
-		&& kubectl -n minio wait pods --for=condition=Ready --timeout=300s --all --all-namespaces \
+		&& kubectl -n minio wait pods --for=condition=Ready --timeout=300s --all \
 		&& kubectl apply -f ./testdata/minio-secret.yaml \
 		&& kubectl apply -f ./testdata/minio-bucket-job.yaml \
 		&& kubectl -n minio wait --for=condition=complete job/minio-create-backup-bucket --timeout=300s\

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -42,6 +42,17 @@ install-tempo:
 		tempo grafana/tempo \
 	  --namespace monitoring
 
+install-minio: update-helm-repos
+	helm upgrade --install \
+		minio minio/minio \
+	  --namespace minio \
+		--create-namespace \
+		--values=./testdata/minio.yaml \
+		&& kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces \
+		&& kubectl apply -f ./testdata/minio-bucket-job.yaml \
+		&& kubectl -n minio wait --for=condition=complete job/minio-create-backup-bucket --timeout=300s\
+		&& kubectl -n minio delete job/minio-create-backup-bucket
+
 enable-cnpg-default-namespace:
 	kubectl label namespace default "tembo-pod-init.tembo.io/watch"="true"
 	kubectl delete pods -n tembo-pod-init --all
@@ -58,6 +69,7 @@ update-helm-repos:
 	helm repo add traefik https://traefik.github.io/charts
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo add grafana https://grafana.github.io/helm-charts
+	helm repo add minio https://charts.min.io/
 	helm repo update
 
 # generate and install crd into the cluster
@@ -77,6 +89,7 @@ start-kind:
 	just install-kube-prometheus-stack
 	just install-tempo
 	just install-traefik
+	just install-minio
 	just install-crd
 	just install-cnpg
 	just install-tembo-pod-init

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -14,7 +14,7 @@ generate-crd:
 
 install-traefik:
 	kubectl create namespace traefik || true
-	helm upgrade --install --version=20.8.0 --namespace=traefik --values=./testdata/traefik-values.yaml traefik traefik/traefik
+	helm upgrade --install --namespace=traefik --version=23.1.0 --values=./testdata/traefik-values.yaml traefik traefik/traefik
 
 install-kube-prometheus-stack:
 	kubectl create namespace monitoring || true

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -42,16 +42,23 @@ install-tempo:
 		tempo grafana/tempo \
 	  --namespace monitoring
 
-install-minio: update-helm-repos
+install-minio:
 	helm upgrade --install \
 		minio minio/minio \
 	  --namespace minio \
 		--create-namespace \
 		--values=./testdata/minio.yaml \
-		&& kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces \
+		&& kubectl -n minio wait pods --for=condition=Ready --timeout=300s --all --all-namespaces \
+		&& kubectl apply -f ./testdata/minio-secret.yaml \
 		&& kubectl apply -f ./testdata/minio-bucket-job.yaml \
 		&& kubectl -n minio wait --for=condition=complete job/minio-create-backup-bucket --timeout=300s\
 		&& kubectl -n minio delete job/minio-create-backup-bucket
+
+install-reflector:
+	helm upgrade --install \
+		reflector emberstack/reflector \
+	  --namespace reflector \
+		--create-namespace 
 
 enable-cnpg-default-namespace:
 	kubectl label namespace default "tembo-pod-init.tembo.io/watch"="true"
@@ -70,6 +77,7 @@ update-helm-repos:
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo add minio https://charts.min.io/
+	helm repo add emberstack https://emberstack.github.io/helm-charts
 	helm repo update
 
 # generate and install crd into the cluster
@@ -86,6 +94,7 @@ start-kind:
 	kind create cluster --image=kindest/node:v{{KUBE_VERSION}} --config testdata/kind-config.yaml
 	just update-helm-repos
 	just enable-cnpg-default-namespace
+	just install-reflector
 	just install-kube-prometheus-stack
 	just install-tempo
 	just install-traefik

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -48,7 +48,7 @@ install-minio:
 	  --namespace minio \
 		--create-namespace \
 		--values=./testdata/minio.yaml \
-		&& kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
+		&& kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces \
 		&& kubectl apply -f ./testdata/minio-secret.yaml \
 		&& kubectl apply -f ./testdata/minio-bucket-job.yaml \
 		&& kubectl -n minio wait --for=condition=complete job/minio-create-backup-bucket --timeout=300s\

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -48,7 +48,7 @@ install-minio:
 	  --namespace minio \
 		--create-namespace \
 		--values=./testdata/minio.yaml \
-		&& kubectl -n minio wait pods --for=condition=Ready --timeout=300s --all \
+		&& kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
 		&& kubectl apply -f ./testdata/minio-secret.yaml \
 		&& kubectl apply -f ./testdata/minio-bucket-job.yaml \
 		&& kubectl -n minio wait --for=condition=complete job/minio-create-backup-bucket --timeout=300s\

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -14,7 +14,7 @@ generate-crd:
 
 install-traefik:
 	kubectl create namespace traefik || true
-	helm upgrade --install --namespace=traefik --version=23.1.0 --values=./testdata/traefik-values.yaml traefik traefik/traefik
+	helm upgrade --install --namespace=traefik --version=20.8.0 --values=./testdata/traefik-values.yaml traefik traefik/traefik
 
 install-kube-prometheus-stack:
 	kubectl create namespace monitoring || true

--- a/tembo-operator/scripts/remove-minio.sh
+++ b/tembo-operator/scripts/remove-minio.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Check if $1 is not provided
+if [ -z "$1" ]; then
+    echo "Error: Missing argument for backup name."
+    exit 1
+fi
+
+# Start the port-forward in the background
+kubectl port-forward -n minio svc/minio 9000:9000 &
+
+# Capture the process ID of the background process
+PORT_FORWARD_PID=$!
+
+# Give it a second to establish the connection
+sleep 1
+
+# Execute the AWS command
+AWS_ACCESS_KEY_ID=tembo AWS_SECRET_ACCESS_KEY=tembo12345 aws s3 ls "s3://tembo-backup/" --endpoint-url http://localhost:9000
+echo "Removing backup $1 from Minio backup path s3://tembo-backup/"
+AWS_ACCESS_KEY_ID=tembo AWS_SECRET_ACCESS_KEY=tembo12345 aws s3 rm "s3://tembo-backup/$1" --recursive --endpoint-url http://localhost:9000
+
+# Kill the port-forward process
+kill $PORT_FORWARD_PID
+

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -1,24 +1,22 @@
-use crate::{app_service::types::AppService, extensions::types::ExtensionStatus};
+use crate::{
+    apis::postgres_parameters::ConfigValue,
+    apis::postgres_parameters::{
+        merge_pg_configs, MergeError, PgConfig, DISALLOWED_CONFIGS, MULTI_VAL_CONFIGS,
+    },
+    app_service::types::AppService,
+    defaults,
+    extensions::types::ExtensionStatus,
+    extensions::types::{Extension, TrunkInstall, TrunkInstallStatus},
+    postgres_exporter::PostgresMetrics,
+};
 
 use k8s_openapi::{
     api::core::v1::ResourceRequirements,
     apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
 };
 
-use crate::{
-    apis::postgres_parameters::{
-        merge_pg_configs, MergeError, PgConfig, DISALLOWED_CONFIGS, MULTI_VAL_CONFIGS,
-    },
-    defaults,
-    postgres_exporter::PostgresMetrics,
-};
-use kube::CustomResource;
-
-use crate::{
-    apis::postgres_parameters::ConfigValue,
-    extensions::types::{Extension, TrunkInstall, TrunkInstallStatus},
-};
 use chrono::{DateTime, Utc};
+use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -34,17 +32,74 @@ pub struct ServiceAccountTemplate {
     pub metadata: Option<ObjectMeta>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+pub struct S3Credentials {
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "accessKeyId")]
+    pub access_key_id: Option<S3CredentialsAccessKeyId>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "inheritFromIAMRole"
+    )]
+    pub inherit_from_iam_role: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<S3CredentialsRegion>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "secretAccessKey")]
+    pub secret_access_key: Option<S3CredentialsSecretAccessKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "sessionToken")]
+    pub session_token: Option<S3CredentialsSessionToken>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+pub struct S3CredentialsAccessKeyId {
+    pub key: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+pub struct S3CredentialsRegion {
+    pub key: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+pub struct S3CredentialsSecretAccessKey {
+    pub key: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+pub struct S3CredentialsSessionToken {
+    pub key: String,
+    pub name: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[allow(non_snake_case)]
 pub struct Backup {
     #[serde(default = "defaults::default_destination_path")]
     pub destinationPath: Option<String>,
-    #[serde(default = "defaults::default_encryption")]
     pub encryption: Option<String>,
     #[serde(default = "defaults::default_retention_policy")]
     pub retentionPolicy: Option<String>,
     #[serde(default = "defaults::default_backup_schedule")]
     pub schedule: Option<String>,
+    #[serde(default, rename = "endpointURL")]
+    pub endpoint_url: Option<String>,
+    #[serde(rename = "s3Credentials")]
+    pub s3_credentials: Option<S3Credentials>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+pub struct Restore {
+    #[serde(rename = "serverName")]
+    pub server_name: String,
+    #[serde(rename = "recoveryTargetTime")]
+    pub recovery_target_time: Option<String>,
+    #[serde(default, rename = "endpointURL")]
+    pub endpoint_url: Option<String>,
+    #[serde(rename = "s3Credentials")]
+    pub s3_credentials: Option<S3Credentials>,
 }
 
 /// Generate the Kubernetes wrapper struct `CoreDB` from our Spec and Status struct
@@ -112,6 +167,9 @@ pub struct CoreDBSpec {
     pub override_configs: Option<Vec<PgConfig>>,
     #[serde(rename = "appServices")]
     pub app_services: Option<Vec<AppService>>,
+
+    // instance restore from backup
+    pub restore: Option<Restore>,
 }
 
 impl CoreDBSpec {

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -77,6 +77,7 @@ pub struct S3CredentialsSessionToken {
 pub struct Backup {
     #[serde(default = "defaults::default_destination_path")]
     pub destinationPath: Option<String>,
+    #[serde(default = "defaults::default_encryption")]
     pub encryption: Option<String>,
     #[serde(default = "defaults::default_retention_policy")]
     pub retentionPolicy: Option<String>,
@@ -84,7 +85,7 @@ pub struct Backup {
     pub schedule: Option<String>,
     #[serde(default, rename = "endpointURL")]
     pub endpoint_url: Option<String>,
-    #[serde(rename = "s3Credentials")]
+    #[serde(default = "defaults::default_s3_credentials", rename = "s3Credentials")]
     pub s3_credentials: Option<S3Credentials>,
 }
 

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -1,12 +1,10 @@
 use crate::{
-    apis::postgres_parameters::ConfigValue,
     apis::postgres_parameters::{
-        merge_pg_configs, MergeError, PgConfig, DISALLOWED_CONFIGS, MULTI_VAL_CONFIGS,
+        merge_pg_configs, ConfigValue, MergeError, PgConfig, DISALLOWED_CONFIGS, MULTI_VAL_CONFIGS,
     },
     app_service::types::AppService,
     defaults,
-    extensions::types::ExtensionStatus,
-    extensions::types::{Extension, TrunkInstall, TrunkInstallStatus},
+    extensions::types::{Extension, ExtensionStatus, TrunkInstall, TrunkInstallStatus},
     postgres_exporter::PostgresMetrics,
 };
 

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -139,9 +139,11 @@ pub fn cnpg_backup_configuration(
                         None => None,
                         Some(encryption) => match encryption.as_str() {
                             "AES256" => Some(ClusterBackupBarmanObjectStoreDataEncryption::Aes256),
+                            "aws:kms" => Some(ClusterBackupBarmanObjectStoreDataEncryption::AwsKms),
                             _ => None,
                         },
                     };
+                    // todo: Expose all compression types(gzip & snappy), not just bzip2
                     Some(ClusterBackupBarmanObjectStoreData {
                         compression: Some(ClusterBackupBarmanObjectStoreDataCompression::Bzip2),
                         encryption,
@@ -149,7 +151,9 @@ pub fn cnpg_backup_configuration(
                         ..ClusterBackupBarmanObjectStoreData::default()
                     })
                 } else {
+                    // todo: Expose all compression types(gzip & snappy), not just bzip2
                     Some(ClusterBackupBarmanObjectStoreData {
+                        compression: Some(ClusterBackupBarmanObjectStoreDataCompression::Bzip2),
                         immediate_checkpoint: Some(true),
                         ..ClusterBackupBarmanObjectStoreData::default()
                     })
@@ -162,9 +166,11 @@ pub fn cnpg_backup_configuration(
                         None => None,
                         Some(encryption) => match encryption.as_str() {
                             "AES256" => Some(ClusterBackupBarmanObjectStoreWalEncryption::Aes256),
+                            "aws:kms" => Some(ClusterBackupBarmanObjectStoreWalEncryption::AwsKms),
                             _ => None,
                         },
                     };
+                    // todo: Expose all compression types(gzip & snappy), not just bzip2
                     Some(ClusterBackupBarmanObjectStoreWal {
                         compression: Some(ClusterBackupBarmanObjectStoreWalCompression::Bzip2),
                         encryption,

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -1,19 +1,32 @@
 use crate::{
-    apis::{coredb_types::CoreDB, postgres_parameters::MergeError},
+    apis::{
+        coredb_types::{CoreDB, S3Credentials},
+        postgres_parameters::MergeError,
+    },
     cloudnativepg::{
         clusters::{
             Cluster, ClusterAffinity, ClusterBackup, ClusterBackupBarmanObjectStore,
             ClusterBackupBarmanObjectStoreData, ClusterBackupBarmanObjectStoreDataCompression,
             ClusterBackupBarmanObjectStoreDataEncryption, ClusterBackupBarmanObjectStoreS3Credentials,
-            ClusterBackupBarmanObjectStoreWal, ClusterBackupBarmanObjectStoreWalCompression,
-            ClusterBackupBarmanObjectStoreWalEncryption, ClusterBootstrap, ClusterBootstrapInitdb,
-            ClusterExternalClusters, ClusterExternalClustersPassword, ClusterLogLevel, ClusterManaged,
-            ClusterManagedRoles, ClusterManagedRolesEnsure, ClusterManagedRolesPasswordSecret,
-            ClusterMonitoring, ClusterMonitoringCustomQueriesConfigMap, ClusterNodeMaintenanceWindow,
-            ClusterPostgresql, ClusterPostgresqlSyncReplicaElectionConstraint, ClusterPrimaryUpdateMethod,
-            ClusterPrimaryUpdateStrategy, ClusterReplicationSlots, ClusterReplicationSlotsHighAvailability,
-            ClusterResources, ClusterServiceAccountTemplate, ClusterServiceAccountTemplateMetadata,
-            ClusterSpec, ClusterStorage, ClusterSuperuserSecret,
+            ClusterBackupBarmanObjectStoreS3CredentialsAccessKeyId,
+            ClusterBackupBarmanObjectStoreS3CredentialsRegion,
+            ClusterBackupBarmanObjectStoreS3CredentialsSecretAccessKey,
+            ClusterBackupBarmanObjectStoreS3CredentialsSessionToken, ClusterBackupBarmanObjectStoreWal,
+            ClusterBackupBarmanObjectStoreWalCompression, ClusterBackupBarmanObjectStoreWalEncryption,
+            ClusterBootstrap, ClusterBootstrapInitdb, ClusterBootstrapRecovery,
+            ClusterBootstrapRecoveryRecoveryTarget, ClusterExternalClusters,
+            ClusterExternalClustersBarmanObjectStore, ClusterExternalClustersBarmanObjectStoreS3Credentials,
+            ClusterExternalClustersBarmanObjectStoreS3CredentialsAccessKeyId,
+            ClusterExternalClustersBarmanObjectStoreS3CredentialsRegion,
+            ClusterExternalClustersBarmanObjectStoreS3CredentialsSecretAccessKey,
+            ClusterExternalClustersBarmanObjectStoreS3CredentialsSessionToken,
+            ClusterExternalClustersBarmanObjectStoreWal, ClusterExternalClustersPassword, ClusterLogLevel,
+            ClusterManaged, ClusterManagedRoles, ClusterManagedRolesEnsure,
+            ClusterManagedRolesPasswordSecret, ClusterMonitoring, ClusterMonitoringCustomQueriesConfigMap,
+            ClusterNodeMaintenanceWindow, ClusterPostgresql, ClusterPostgresqlSyncReplicaElectionConstraint,
+            ClusterPrimaryUpdateMethod, ClusterPrimaryUpdateStrategy, ClusterReplicationSlots,
+            ClusterReplicationSlotsHighAvailability, ClusterResources, ClusterServiceAccountTemplate,
+            ClusterServiceAccountTemplateMetadata, ClusterSpec, ClusterStorage, ClusterSuperuserSecret,
         },
         scheduledbackups::{
             ScheduledBackup, ScheduledBackupBackupOwnerReference, ScheduledBackupCluster, ScheduledBackupSpec,
@@ -21,10 +34,12 @@ use crate::{
     },
     config::Config,
     defaults::{default_image, default_llm_image},
+    errors::ValueError,
     patch_cdb_status_merge,
     trunk::extensions_that_require_load,
     Context, RESTARTED_AT,
 };
+use chrono::{DateTime, NaiveDateTime, Offset};
 use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use kube::{
     api::{Patch, PatchParams},
@@ -45,6 +60,7 @@ pub fn cnpg_backup_configuration(
     cdb: &CoreDB,
     cfg: &Config,
 ) -> (Option<ClusterBackup>, Option<ClusterServiceAccountTemplate>) {
+    let mut service_account_template: Option<ClusterServiceAccountTemplate> = None;
     // Check to make sure that backups are enabled, and return None if it is disabled.
     if !cfg.enable_backup {
         (None, None)
@@ -56,30 +72,50 @@ pub fn cnpg_backup_configuration(
             warn!("Backups are disabled because we don't have an S3 backup path");
             return (None, None);
         }
-        let service_account_metadata = cdb.spec.serviceAccountTemplate.metadata.clone();
-        if service_account_metadata.is_none() {
-            warn!("Backups are disabled because we don't have a service account template");
-            return (None, None);
-        }
-        let service_account_annotations = service_account_metadata
-            .expect("Expected service account template metadata")
-            .annotations;
-        if service_account_annotations.is_none() {
-            warn!("Backups are disabled because we don't have a service account template with annotations");
-            return (None, None);
-        }
-        let service_account_annotations =
-            service_account_annotations.expect("Expected service account template annotations");
-        let service_account_role_arn = service_account_annotations.get("eks.amazonaws.com/role-arn");
-        if service_account_role_arn.is_none() {
-            warn!(
+        // If backup.endpoint_url & backup.s3_credentials is not set, then we need to use the service account template
+        // to get the EKS role ARN to setup backups
+        if cdb.spec.backup.endpoint_url.is_none() && cdb.spec.backup.s3_credentials.is_none() {
+            let service_account_metadata = cdb.spec.serviceAccountTemplate.metadata.clone();
+            if service_account_metadata.is_none() {
+                warn!("Backups are disabled because we don't have a service account template");
+                return (None, None);
+            }
+            let service_account_annotations = service_account_metadata
+                .expect("Expected service account template metadata")
+                .annotations;
+            if service_account_annotations.is_none() {
+                warn!(
+                    "Backups are disabled because we don't have a service account template with annotations"
+                );
+                return (None, None);
+            }
+            let service_account_annotations =
+                service_account_annotations.expect("Expected service account template annotations");
+            let service_account_role_arn = service_account_annotations.get("eks.amazonaws.com/role-arn");
+            if service_account_role_arn.is_none() {
+                warn!(
                 "Backups are disabled because we don't have a service account template with an EKS role ARN"
             );
-            return (None, None);
+                return (None, None);
+            }
+            let role_arn = service_account_role_arn
+                .expect("Expected service account template annotations to contain an EKS role ARN")
+                .clone();
+
+            service_account_template = Some(ClusterServiceAccountTemplate {
+                metadata: ClusterServiceAccountTemplateMetadata {
+                    annotations: Some(BTreeMap::from([(
+                        "eks.amazonaws.com/role-arn".to_string(),
+                        role_arn,
+                    )])),
+                    ..ClusterServiceAccountTemplateMetadata::default()
+                },
+            });
         }
-        let role_arn = service_account_role_arn
-            .expect("Expected service account template annotations to contain an EKS role ARN")
-            .clone();
+
+        // Copy the endpoint_url and s3_credentials from cdb to configure backups
+        let endpoint_url = cdb.spec.backup.endpoint_url.as_deref().unwrap_or_default();
+        let s3_credentials = generate_s3_backup_credentials(cdb.spec.backup.s3_credentials.as_ref());
 
         let retention_days = match &cdb.spec.backup.retentionPolicy {
             None => "30d".to_string(),
@@ -98,42 +134,114 @@ pub fn cnpg_backup_configuration(
 
         let cluster_backup = Some(ClusterBackup {
             barman_object_store: Some(ClusterBackupBarmanObjectStore {
-                data: Some(ClusterBackupBarmanObjectStoreData {
-                    compression: Some(ClusterBackupBarmanObjectStoreDataCompression::Bzip2),
-                    encryption: Some(ClusterBackupBarmanObjectStoreDataEncryption::Aes256),
-                    immediate_checkpoint: Some(true),
-                    ..ClusterBackupBarmanObjectStoreData::default()
-                }),
+                data: if cdb.spec.backup.encryption.is_some() {
+                    let encryption = match &cdb.spec.backup.encryption {
+                        None => None,
+                        Some(encryption) => match encryption.as_str() {
+                            "AES256" => Some(ClusterBackupBarmanObjectStoreDataEncryption::Aes256),
+                            _ => None,
+                        },
+                    };
+                    Some(ClusterBackupBarmanObjectStoreData {
+                        compression: Some(ClusterBackupBarmanObjectStoreDataCompression::Bzip2),
+                        encryption,
+                        immediate_checkpoint: Some(true),
+                        ..ClusterBackupBarmanObjectStoreData::default()
+                    })
+                } else {
+                    Some(ClusterBackupBarmanObjectStoreData {
+                        immediate_checkpoint: Some(true),
+                        ..ClusterBackupBarmanObjectStoreData::default()
+                    })
+                },
+                endpoint_url: Some(endpoint_url.to_string()),
                 destination_path: backup_path.expect("Expected to find S3 path"),
-                s3_credentials: Some(ClusterBackupBarmanObjectStoreS3Credentials {
-                    inherit_from_iam_role: Some(true),
-                    ..ClusterBackupBarmanObjectStoreS3Credentials::default()
-                }),
-                wal: Some(ClusterBackupBarmanObjectStoreWal {
-                    compression: Some(ClusterBackupBarmanObjectStoreWalCompression::Bzip2),
-                    encryption: Some(ClusterBackupBarmanObjectStoreWalEncryption::Aes256),
-                    max_parallel: Some(5),
-                }),
+                s3_credentials: Some(s3_credentials),
+                wal: if cdb.spec.backup.encryption.is_some() {
+                    let encryption = match &cdb.spec.backup.encryption {
+                        None => None,
+                        Some(encryption) => match encryption.as_str() {
+                            "AES256" => Some(ClusterBackupBarmanObjectStoreWalEncryption::Aes256),
+                            _ => None,
+                        },
+                    };
+                    Some(ClusterBackupBarmanObjectStoreWal {
+                        compression: Some(ClusterBackupBarmanObjectStoreWalCompression::Bzip2),
+                        encryption,
+                        max_parallel: Some(5),
+                    })
+                } else {
+                    None
+                },
                 ..ClusterBackupBarmanObjectStore::default()
             }),
             retention_policy: Some(retention_days),
             ..ClusterBackup::default()
         });
 
-        let service_account_template = Some(ClusterServiceAccountTemplate {
-            metadata: ClusterServiceAccountTemplateMetadata {
-                annotations: Some(BTreeMap::from([(
-                    "eks.amazonaws.com/role-arn".to_string(),
-                    role_arn,
-                )])),
-                ..ClusterServiceAccountTemplateMetadata::default()
-            },
-        });
-
         (cluster_backup, service_account_template)
     }
 }
 
+// parse_target_time returns the parsed target_time which is used for point-in-time-recovery
+// Currently, we support formats of target_time as follows (Basically support what CNPG supports):
+// YYYY-MM-DD HH24:MI:SS
+// YYYY-MM-DD HH24:MI:SS.FF6TZH
+// YYYY-MM-DD HH24:MI:SS.FF6TZH:TZM
+// YYYY-MM-DDTHH24:MI:SSZ            (RFC3339)
+// YYYY-MM-DDTHH24:MI:SS±TZH:TZM     (RFC3339)
+// YYYY-MM-DDTHH24:MI:SSS±TZH:TZM	   (RFC3339Micro)
+// YYYY-MM-DDTHH24:MI:SS             (modified RFC3339)
+fn parse_target_time(target_time: Option<&str>) -> Result<Option<String>, ValueError> {
+    if let Some(time_str) = target_time {
+        // Try to parse the target_time with the following formats in order
+        // 1. YYYY-MM-DD HH24:MI:SS
+        let result = NaiveDateTime::parse_from_str(time_str, "%Y-%m-%d %H:%M:%S")
+            .map(|dt| dt.to_string())
+            .or_else(|_| {
+                // 2. YYYY-MM-DD HH24:MI:SS.FF6TZH
+                // 3. YYYY-MM-DD HH24:MI:SS.FF6TZH:TZM
+                DateTime::parse_from_str(time_str, "%Y-%m-%d %H:%M:%S%.6f%z").map(|dt| {
+                    let offset_hours = dt.offset().fix().local_minus_utc() / 3600;
+                    let formatted_offset = format!("{:+03}", offset_hours);
+                    format!(
+                        "{}.{:06}{}",
+                        dt.format("%Y-%m-%d %H:%M:%S"),
+                        dt.timestamp_subsec_micros(),
+                        formatted_offset
+                    )
+                })
+            })
+            .or_else(|_| {
+                // 4. YYYY-MM-DDTHH24:MI:SSZ            (RFC3339)
+                // 5. YYYY-MM-DDTHH24:MI:SS±TZH:TZM     (RFC3339)
+                // 6. YYYY-MM-DDTHH24:MI:SSS±TZH:TZM    (RFC3339Micro)
+                // 7. YYYY-MM-DDTHH24:MI:SS             (modified RFC3339)
+                DateTime::parse_from_rfc3339(time_str).map(|dt| {
+                    let offset_hours = dt.offset().fix().local_minus_utc() / 3600;
+                    let formatted_offset = format!("{:+03}", offset_hours);
+                    format!(
+                        "{}.{:06}{}",
+                        dt.format("%Y-%m-%d %H:%M:%S"),
+                        dt.timestamp_subsec_micros(),
+                        formatted_offset
+                    )
+                })
+            });
+
+        // Return the parsed target_time if it is Ok, otherwise return ValueError
+        // todo: Somehow turn this into a requeue action, so that we can retry
+        //      when the target_time is not in the correct format.
+        match result {
+            Ok(parsed_time) => Ok(Some(parsed_time)),
+            Err(err) => Err(ValueError::ChronoParseError(err)),
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+#[instrument(skip(cdb))]
 pub fn cnpg_cluster_bootstrap_from_cdb(
     cdb: &CoreDB,
 ) -> (
@@ -141,12 +249,48 @@ pub fn cnpg_cluster_bootstrap_from_cdb(
     Option<Vec<ClusterExternalClusters>>,
     Option<ClusterSuperuserSecret>,
 ) {
-    // todo: Add logic if restore is needed
-    let cluster_bootstrap = ClusterBootstrap {
-        initdb: Some(ClusterBootstrapInitdb {
-            ..ClusterBootstrapInitdb::default()
-        }),
-        ..ClusterBootstrap::default()
+    // parse_target_time returns the parsed target_time which is used for point-in-time-recovery
+    // todo: Somehow turn this into a requeue action, so that we can retry when the target_time is not in the correct format.
+    //      for now we just log the error and return None, which will disable point-in-time-recovery, but allow for a full recovery
+    let parsed_target_time = cdb.spec.restore.as_ref().and_then(|restore| {
+        restore
+            .recovery_target_time
+            .as_ref()
+            .and_then(|time_str| match parse_target_time(Some(time_str)) {
+                Ok(Some(parsed_time)) => Some(parsed_time),
+                Ok(None) => None,
+                Err(err) => {
+                    error!(
+                        "Failed to parse target_time for instance: {}, {}",
+                        cdb.name_any(),
+                        err
+                    );
+                    None
+                }
+            })
+    });
+
+    let cluster_bootstrap = if let Some(_restore) = &cdb.spec.restore {
+        ClusterBootstrap {
+            recovery: Some(ClusterBootstrapRecovery {
+                source: Some("tembo-recovery".to_string()),
+                recovery_target: parsed_target_time.map(|target_time| {
+                    ClusterBootstrapRecoveryRecoveryTarget {
+                        target_time: Some(target_time),
+                        ..ClusterBootstrapRecoveryRecoveryTarget::default()
+                    }
+                }),
+                ..ClusterBootstrapRecovery::default()
+            }),
+            ..ClusterBootstrap::default()
+        }
+    } else {
+        ClusterBootstrap {
+            initdb: Some(ClusterBootstrapInitdb {
+                ..ClusterBootstrapInitdb::default()
+            }),
+            ..ClusterBootstrap::default()
+        }
     };
     let cluster_name = cdb.name_any();
 
@@ -157,17 +301,41 @@ pub fn cnpg_cluster_bootstrap_from_cdb(
 
     let superuser_secret_name = format!("{}-connection", cluster_name);
 
-    let coredb_cluster = ClusterExternalClusters {
-        name: "coredb".to_string(),
-        connection_parameters: Some(coredb_connection_parameters),
-        password: Some(ClusterExternalClustersPassword {
-            // The CoreDB operator connection secret is named as the cluster
-            // name, suffixed by -connection
-            name: Some(superuser_secret_name.clone()),
-            key: "password".to_string(),
-            ..ClusterExternalClustersPassword::default()
-        }),
-        ..ClusterExternalClusters::default()
+    let coredb_cluster = if let Some(restore) = &cdb.spec.restore {
+        let s3_credentials = generate_s3_restore_credentials(restore.s3_credentials.as_ref());
+        // Find destination_path from Backup to generate the restore destination path
+        let restore_destination_path = match &cdb.spec.backup.destinationPath {
+            Some(path) => generate_restore_destination_path(path),
+            None => "".to_string(), // or any other default value you'd like
+        };
+        ClusterExternalClusters {
+            name: "tembo-recovery".to_string(),
+            barman_object_store: Some(ClusterExternalClustersBarmanObjectStore {
+                destination_path: format!("{}/{}", restore_destination_path, restore.server_name),
+                endpoint_url: restore.endpoint_url.clone(),
+                s3_credentials: Some(s3_credentials),
+                wal: Some(ClusterExternalClustersBarmanObjectStoreWal {
+                    max_parallel: Some(5),
+                    ..ClusterExternalClustersBarmanObjectStoreWal::default()
+                }),
+                server_name: Some(restore.server_name.clone()),
+                ..ClusterExternalClustersBarmanObjectStore::default()
+            }),
+            ..ClusterExternalClusters::default()
+        }
+    } else {
+        ClusterExternalClusters {
+            name: "coredb".to_string(),
+            connection_parameters: Some(coredb_connection_parameters),
+            password: Some(ClusterExternalClustersPassword {
+                // The CoreDB operator connection secret is named as the cluster
+                // name, suffixed by -connection
+                name: Some(superuser_secret_name.clone()),
+                key: "password".to_string(),
+                ..ClusterExternalClustersPassword::default()
+            }),
+            ..ClusterExternalClusters::default()
+        }
     };
 
     let superuser_secret = ClusterSuperuserSecret {
@@ -473,7 +641,7 @@ async fn pods_to_fence(cdb: &CoreDB, ctx: Arc<Context>) -> Result<Vec<String>, A
                         }
                     }
                     Ok(None) => {
-                        warn!("Latest generated node is not available yet. It might be a new or initializing cluster.");
+                        warn!("Latest generated node is not available yet for instance {}. It might be a new or initializing cluster.", &cdb.name_any());
                         Err(Action::requeue(Duration::from_secs(30)))
                     }
                     Err(e) => {
@@ -1070,6 +1238,111 @@ pub async fn unfence_pod(cdb: &CoreDB, ctx: Arc<Context>, pod_name: &str) -> Res
     }
 }
 
+// generate_restore_destination_path function will generate the restore destination path from the backup
+// object and return a string
+fn generate_restore_destination_path(path: &str) -> String {
+    let mut parts: Vec<&str> = path.split('/').collect();
+    parts.pop();
+    parts.join("/")
+}
+
+// generate_s3_backup_credentials function will generate the s3 backup credentials from
+// S3Credentials object and return a ClusterBackupBarmanObjectStoreS3Credentials object
+fn generate_s3_backup_credentials(
+    creds: Option<&S3Credentials>,
+) -> ClusterBackupBarmanObjectStoreS3Credentials {
+    if let Some(creds) = creds {
+        if creds.access_key_id.is_none() && creds.secret_access_key.is_none() {
+            return ClusterBackupBarmanObjectStoreS3Credentials {
+                inherit_from_iam_role: Some(true),
+                ..Default::default()
+            };
+        }
+
+        ClusterBackupBarmanObjectStoreS3Credentials {
+            access_key_id: creds.access_key_id.as_ref().map(|id| {
+                ClusterBackupBarmanObjectStoreS3CredentialsAccessKeyId {
+                    key: id.key.clone(),
+                    name: id.name.clone(),
+                }
+            }),
+            inherit_from_iam_role: Some(false),
+            region: creds
+                .region
+                .as_ref()
+                .map(|r| ClusterBackupBarmanObjectStoreS3CredentialsRegion {
+                    key: r.key.clone(),
+                    name: r.name.clone(),
+                }),
+            secret_access_key: creds.secret_access_key.as_ref().map(|key| {
+                ClusterBackupBarmanObjectStoreS3CredentialsSecretAccessKey {
+                    key: key.key.clone(),
+                    name: key.name.clone(),
+                }
+            }),
+            session_token: creds.session_token.as_ref().map(|token| {
+                ClusterBackupBarmanObjectStoreS3CredentialsSessionToken {
+                    key: token.key.clone(),
+                    name: token.name.clone(),
+                }
+            }),
+        }
+    } else {
+        ClusterBackupBarmanObjectStoreS3Credentials {
+            inherit_from_iam_role: Some(true),
+            ..Default::default()
+        }
+    }
+}
+
+// generate_s3_restore_credentials function will generate the s3 restore credentials from
+// S3Credentials object and return a ClusterExternalClustersBarmanObjectStoreS3Credentials object
+fn generate_s3_restore_credentials(
+    creds: Option<&S3Credentials>,
+) -> ClusterExternalClustersBarmanObjectStoreS3Credentials {
+    if let Some(creds) = creds {
+        if creds.access_key_id.is_none() && creds.secret_access_key.is_none() {
+            return ClusterExternalClustersBarmanObjectStoreS3Credentials {
+                inherit_from_iam_role: Some(true),
+                ..Default::default()
+            };
+        }
+
+        ClusterExternalClustersBarmanObjectStoreS3Credentials {
+            access_key_id: creds.access_key_id.as_ref().map(|id| {
+                ClusterExternalClustersBarmanObjectStoreS3CredentialsAccessKeyId {
+                    key: id.key.clone(),
+                    name: id.name.clone(),
+                }
+            }),
+            inherit_from_iam_role: Some(false),
+            region: creds.region.as_ref().map(|r| {
+                ClusterExternalClustersBarmanObjectStoreS3CredentialsRegion {
+                    key: r.key.clone(),
+                    name: r.name.clone(),
+                }
+            }),
+            secret_access_key: creds.secret_access_key.as_ref().map(|key| {
+                ClusterExternalClustersBarmanObjectStoreS3CredentialsSecretAccessKey {
+                    key: key.key.clone(),
+                    name: key.name.clone(),
+                }
+            }),
+            session_token: creds.session_token.as_ref().map(|token| {
+                ClusterExternalClustersBarmanObjectStoreS3CredentialsSessionToken {
+                    key: token.key.clone(),
+                    name: token.name.clone(),
+                }
+            }),
+        }
+    } else {
+        ClusterExternalClustersBarmanObjectStoreS3Credentials {
+            inherit_from_iam_role: Some(true),
+            ..Default::default()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1654,5 +1927,59 @@ mod tests {
         }
         "#;
         let _result: Cluster = serde_json::from_str(json_str).expect("Should be able to deserialize");
+    }
+
+    #[test]
+    fn test_generate_restore_destination_path() {
+        // Define test cases
+        let test_cases = vec![
+            (
+                "s3://cdb-plat-use1-dev-instance-backups/coredb/coredb/org-coredb-inst-test-testing-test-1",
+                "s3://cdb-plat-use1-dev-instance-backups/coredb/coredb",
+            ),
+            ("s3://path/with/multiple/segments", "s3://path/with/multiple"),
+            ("s3://short/path", "s3://short"),
+            ("single_segment", ""),
+        ];
+
+        for (input, expected) in test_cases.iter() {
+            assert_eq!(generate_restore_destination_path(input), *expected);
+        }
+    }
+
+    #[test]
+    fn test_basic_format() {
+        let result = parse_target_time(Some("2023-09-26 21:15:42")).unwrap();
+        assert_eq!(result, Some("2023-09-26 21:15:42".to_string()));
+    }
+
+    #[test]
+    fn test_milliseconds_and_offset() {
+        let result = parse_target_time(Some("2023-09-26 21:15:42.123456+02:00")).unwrap();
+        assert_eq!(result, Some("2023-09-26 21:15:42.123456+02".to_string()));
+    }
+
+    #[test]
+    fn test_rfc3339() {
+        let result = parse_target_time(Some("2023-09-26T21:15:42Z")).unwrap();
+        assert_eq!(result, Some("2023-09-26 21:15:42.000000+00".to_string())); // adjusted expected output
+    }
+
+    #[test]
+    fn test_rfc3339_with_offset() {
+        let result = parse_target_time(Some("2023-09-26T21:15:42+05:00")).unwrap();
+        assert_eq!(result, Some("2023-09-26 21:15:42.000000+05".to_string())); // adjusted expected output
+    }
+
+    #[test]
+    fn test_rfc3339micro() {
+        let result = parse_target_time(Some("2023-09-26T21:15:42.123456+05:00")).unwrap();
+        assert_eq!(result, Some("2023-09-26 21:15:42.123456+05".to_string())); // adjusted expected output
+    }
+
+    #[test]
+    fn test_invalid_format() {
+        let result = parse_target_time(Some("invalid-format"));
+        assert!(result.is_err()); // check for error
     }
 }

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -243,7 +243,6 @@ impl CoreDB {
                 Action::requeue(Duration::from_secs(300))
             })?;
 
-
         // Check if Postgres is already running
         is_not_restarting(self, ctx.clone(), "postgres").await?;
 
@@ -811,7 +810,6 @@ mod test {
         let expected_time = NaiveDate::from_ymd_opt(2023, 9, 19)
             .and_then(|date| date.and_hms_opt(23, 14, 0))
             .map(|naive_dt| DateTime::from_naive_utc_and_offset(naive_dt, Utc));
-
         assert_eq!(oldest_backup_time, expected_time);
     }
 

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -2,7 +2,7 @@ use k8s_openapi::{api::core::v1::ResourceRequirements, apimachinery::pkg::api::r
 use std::collections::BTreeMap;
 
 use crate::{
-    apis::coredb_types::{Backup, ServiceAccountTemplate},
+    apis::coredb_types::{Backup, S3Credentials, ServiceAccountTemplate},
     extensions::types::{Extension, TrunkInstall},
 };
 
@@ -96,15 +96,20 @@ pub fn default_service_account_template() -> ServiceAccountTemplate {
 pub fn default_backup() -> Backup {
     Backup {
         destinationPath: default_destination_path(),
-        encryption: None,
+        encryption: default_encryption(),
         retentionPolicy: default_retention_policy(),
         schedule: default_backup_schedule(),
+        s3_credentials: default_s3_credentials(),
         ..Default::default()
     }
 }
 
 pub fn default_destination_path() -> Option<String> {
     Some("s3://".to_string())
+}
+
+pub fn default_encryption() -> Option<String> {
+    Some("AES256".to_owned())
 }
 
 pub fn default_retention_policy() -> Option<String> {
@@ -114,4 +119,11 @@ pub fn default_retention_policy() -> Option<String> {
 pub fn default_backup_schedule() -> Option<String> {
     // Every day at midnight
     Some("0 0 * * *".to_owned())
+}
+
+pub fn default_s3_credentials() -> Option<S3Credentials> {
+    Some(S3Credentials {
+        inherit_from_iam_role: Some(true),
+        ..Default::default()
+    })
 }

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -96,18 +96,15 @@ pub fn default_service_account_template() -> ServiceAccountTemplate {
 pub fn default_backup() -> Backup {
     Backup {
         destinationPath: default_destination_path(),
-        encryption: default_encryption(),
+        encryption: None,
         retentionPolicy: default_retention_policy(),
         schedule: default_backup_schedule(),
+        ..Default::default()
     }
 }
 
 pub fn default_destination_path() -> Option<String> {
     Some("s3://".to_string())
-}
-
-pub fn default_encryption() -> Option<String> {
-    Some("AES256".to_owned())
 }
 
 pub fn default_retention_policy() -> Option<String> {

--- a/tembo-operator/src/errors.rs
+++ b/tembo-operator/src/errors.rs
@@ -28,4 +28,6 @@ pub enum ValueError {
     ByteError(#[from] Utf8Error),
     #[error("FloatError: {0}")]
     FloatError(#[from] std::num::ParseFloatError),
+    #[error("DateTime Parse Error: {0}")]
+    ChronoParseError(#[from] chrono::format::ParseError),
 }

--- a/tembo-operator/src/extensions/install.rs
+++ b/tembo-operator/src/extensions/install.rs
@@ -10,7 +10,7 @@ use crate::{
 use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use kube::{runtime::controller::Action, Api};
 use std::{collections::HashSet, sync::Arc, time::Duration};
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::apis::coredb_types::CoreDBStatus;
 
@@ -51,8 +51,6 @@ fn merge_and_deduplicate_pods(non_fenced_pods: Vec<Pod>, fenced_names: Option<Ve
 // Collect any fenced pods and add them to the list of pods to install extensions into
 #[instrument(skip(ctx, cdb) fields(trace_id))]
 async fn all_fenced_and_non_fenced_pods(cdb: &CoreDB, ctx: Arc<Context>) -> Result<Vec<Pod>, Action> {
-    let span = span!(Level::DEBUG, "all_fenced_and_non_fenced_pods");
-    let _enter = span.enter();
     let name = cdb.metadata.name.clone().expect("CoreDB should have a name");
 
     // Get fenced pods
@@ -76,9 +74,6 @@ async fn all_fenced_and_non_fenced_pods(cdb: &CoreDB, ctx: Arc<Context>) -> Resu
 /// Find all trunk installs to remove and return a list of strings
 #[instrument(skip(cdb) fields(trace_id))]
 fn find_trunk_installs_to_remove_from_status(cdb: &CoreDB) -> Vec<String> {
-    let span = span!(Level::DEBUG, "remove_trunk_installs_from_status");
-    let _enter = span.enter();
-
     debug!(
         "Checking for trunk installs to remove from status for {}",
         cdb.metadata.name.clone().expect("CoreDB should have a name")
@@ -120,9 +115,6 @@ fn find_trunk_installs_to_remove_from_status(cdb: &CoreDB) -> Vec<String> {
 /// TrunkInstall, which is owned by CoreDB we only need to define a lifetime for CoreDB
 #[instrument(skip(cdb, pod_name) fields(trace_id))]
 fn find_trunk_installs_to_pod<'a>(cdb: &'a CoreDB, pod_name: &str) -> Vec<&'a TrunkInstall> {
-    let span = span!(Level::DEBUG, "find_trunk_installs_to_pod");
-    let _enter = span.enter();
-
     debug!(
         "Checking for trunk installs to install on pod {} for {}",
         pod_name,
@@ -159,9 +151,6 @@ fn find_trunk_installs_to_pod<'a>(cdb: &'a CoreDB, pod_name: &str) -> Vec<&'a Tr
 // is_pod_fenced function checks if a pod is fenced and returns a bool or requeue action
 #[instrument(skip(cdb, ctx, pod_name) fields(trace_id))]
 async fn is_pod_fenced(cdb: &CoreDB, ctx: Arc<Context>, pod_name: &str) -> Result<bool, Action> {
-    let span = span!(Level::DEBUG, "is_pod_fenced");
-    let _enter = span.enter();
-
     let coredb_name = cdb.metadata.name.as_deref().unwrap_or_default();
 
     debug!(
@@ -187,9 +176,6 @@ pub async fn reconcile_trunk_installs(
     cdb: &CoreDB,
     ctx: Arc<Context>,
 ) -> Result<Vec<TrunkInstallStatus>, Action> {
-    let span = span!(Level::INFO, "reconcile_trunk_installs");
-    let _enter = span.enter();
-
     let instance_name = cdb.metadata.name.clone().expect("CoreDB should have a name");
 
     debug!("Starting to reconcile trunk installs for {}", instance_name);
@@ -394,9 +380,6 @@ pub async fn install_extensions_to_pod(
     ctx: &Arc<Context>,
     pod_name: String,
 ) -> Result<Vec<TrunkInstallStatus>, Action> {
-    let span = span!(Level::INFO, "install_extensions");
-    let _enter = span.enter();
-
     let coredb_name = cdb.metadata.name.clone().expect("CoreDB should have a name");
     let coredb_api: Api<CoreDB> = Api::namespaced(
         ctx.client.clone(),
@@ -414,14 +397,9 @@ pub async fn install_extensions_to_pod(
         return Ok(current_trunk_install_statuses);
     }
     info!("Installing extensions into {}: {:?}", coredb_name, trunk_installs);
-    let span = span!(Level::INFO, "install_each_extension");
-    let _enter = span.enter();
 
     let mut requeue = false;
     for ext in trunk_installs.iter() {
-        // Nested span for individual extension installation
-        let ext_span = span!(Level::DEBUG, "install_individual_extension", extension = ext.name);
-        let _ext_enter = ext_span.enter();
         info!("Attempting to install extension: {} on {}", ext.name, coredb_name);
 
         // Execute trunk install command
@@ -497,11 +475,10 @@ mod tests {
             .iter()
             .filter_map(|pod| pod.metadata.name.clone())
             .collect();
-        assert_eq!(deduplicated_names, vec![
-            "pod1".to_string(),
-            "pod2".to_string(),
-            "pod3".to_string()
-        ]);
+        assert_eq!(
+            deduplicated_names,
+            vec!["pod1".to_string(), "pod2".to_string(), "pod3".to_string()]
+        );
     }
 
     #[test]

--- a/tembo-operator/src/extensions/install.rs
+++ b/tembo-operator/src/extensions/install.rs
@@ -475,10 +475,11 @@ mod tests {
             .iter()
             .filter_map(|pod| pod.metadata.name.clone())
             .collect();
-        assert_eq!(
-            deduplicated_names,
-            vec!["pod1".to_string(), "pod2".to_string(), "pod3".to_string()]
-        );
+        assert_eq!(deduplicated_names, vec![
+            "pod1".to_string(),
+            "pod2".to_string(),
+            "pod3".to_string()
+        ]);
     }
 
     #[test]

--- a/tembo-operator/testdata/minio-bucket-job.yaml
+++ b/tembo-operator/testdata/minio-bucket-job.yaml
@@ -13,7 +13,7 @@ spec:
         - /bin/sh
         - -c
         args:
-        - aws s3 mb s3://tembo-backups --endpoint-url http://minio.minio.svc.cluster.local:9000
+        - aws s3 mb s3://tembo-backup --endpoint-url http://minio.minio.svc.cluster.local:9000
         env:
         - name: AWS_ACCESS_KEY_ID
           value: "tembo"

--- a/tembo-operator/testdata/minio-bucket-job.yaml
+++ b/tembo-operator/testdata/minio-bucket-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-backup-bucket
+  namespace: minio
+spec:
+  template:
+    spec:
+      containers:
+      - name: create-bucket
+        image: amazon/aws-cli:latest
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - aws s3 mb s3://tembo-backups --endpoint-url http://minio.minio.svc.cluster.local:9000
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          value: "tembo"
+        - name: AWS_SECRET_ACCESS_KEY
+          value: "tembo12345"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tembo-operator/testdata/minio-secret.yaml
+++ b/tembo-operator/testdata/minio-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3creds
+  namespace: minio
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+data:
+  MINIO_ACCESS_KEY: dGVtYm8=
+  MINIO_SECRET_KEY: dGVtYm8xMjM0NQ==
+type: Opaque

--- a/tembo-operator/testdata/minio.yaml
+++ b/tembo-operator/testdata/minio.yaml
@@ -1,0 +1,8 @@
+mode: standalone
+persistence:
+  enabled: true
+  size: 10Gi
+users:
+  - accessKey: tembo
+    secretKey: tembo12345
+    policy: readwrite

--- a/tembo-operator/testdata/pod-init.yaml
+++ b/tembo-operator/testdata/pod-init.yaml
@@ -3,7 +3,7 @@ image:
 logLevel: info
 extraEnv:
   - name: OPENTELEMETRY_ENDPOINT_URL
-    value: http://tempo.monitoring.svc.cluster.local:4318
+    value: http://tempo.monitoring.svc.cluster.local:4317
 resources:
   requests:
     cpu: 50m

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -3377,6 +3377,7 @@ mod test {
                     "destinationPath": backup_location,
                     "retentionPolicy": "30",
                     "schedule": "17 9 * * *",
+                    "encryption": "",
                     "endpointURL": "http://minio.minio.svc.cluster.local:9000",
                     "s3Credentials": {
                         "accessKeyId": {
@@ -3503,6 +3504,7 @@ mod test {
                     "retentionPolicy": "30",
                     "schedule": "17 9 * * *",
                     "endpointURL": "http://minio.minio.svc.cluster.local:9000",
+                    "encryption": "",
                     "s3Credentials": {
                         "accessKeyId": {
                             "name": "s3creds",

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -18,8 +18,7 @@ mod test {
     use chrono::{DateTime, SecondsFormat, Utc};
     use controller::{
         apis::coredb_types::CoreDB,
-        cloudnativepg::backups::Backup,
-        cloudnativepg::clusters::Cluster,
+        cloudnativepg::{backups::Backup, clusters::Cluster},
         defaults::{default_resources, default_storage},
         ingress_route_crd::IngressRoute,
         ingress_route_tcp_crd::IngressRouteTCP,

--- a/tembo-operator/yaml/sample-machine-learning-backup.yaml
+++ b/tembo-operator/yaml/sample-machine-learning-backup.yaml
@@ -1,0 +1,103 @@
+apiVersion: coredb.io/v1alpha1
+kind: CoreDB
+metadata:
+  name: sample-machine-learning
+spec:
+  image: "quay.io/tembo/ml-cnpg:15.3.0-1-a3e532d"
+  backup:
+    destinationPath: s3://tembo-backup/sample-standard-backup
+    retentionPolicy: "30"
+    schedule: 17 9 * * *
+    endpointURL: http://minio.minio.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: s3creds
+        key: MINIO_ACCESS_KEY
+      secretAccessKey:
+        name: s3creds
+        key: MINIO_SECRET_KEY
+  stop: false
+  stack:
+    name: MachineLearning
+    postgres_config:
+      - name: pg_stat_statements.track
+        value: all
+      - name: cron.host
+        value: /controller/run
+      - name: track_io_timing
+        value: 'on'
+      - name: shared_preload_libraries
+        value: vectorize,pg_stat_statements,pgml,pg_cron,pg_later
+  trunk_installs:
+    - name: pgvector
+      version: 0.5.0
+    - name: pgml
+      version: 2.7.1
+    - name: pg_embedding
+      version: 0.1.0
+    - name: pg_cron
+      version: 1.5.2
+    - name: pgmq
+      version: 0.14.2
+    - name: vectorize
+      version: 0.0.2
+    - name: pg_later
+      version: 0.0.8
+  extensions:
+    # trunk project pg_vector
+    - name: vector
+      locations:
+        - database: postgres
+          enabled: true
+          version: 0.5.0
+    # trunk project postgresml
+    - name: pgml
+      locations:
+        - database: postgres
+          enabled: true
+          version: 2.7.1
+    # trunk project pg_embedding
+    - name: embedding
+      locations:
+        - database: postgres
+          enabled: false
+          version: 0.1.0
+    - name: pg_cron
+      description: pg_cron
+      locations:
+        - database: postgres
+          enabled: true
+          version: 1.5.2
+    - name: pgmq
+      description: pgmq
+      locations:
+        - database: postgres
+          enabled: true
+          version: 0.14.2
+    - name: vectorize
+      description: simple vector search
+      locations:
+        - database: postgres
+          enabled: true
+          version: 0.0.2
+    - name: pg_later
+      description: async query execution
+      locations:
+        - database: postgres
+          enabled: true
+          version: 0.0.8
+  runtime_config:
+    - name: shared_buffers
+      value: "1024MB"
+    - name: max_connections
+      value: "431"
+    - name: work_mem
+      value: "5MB"
+    - name: bgwriter_delay
+      value: "200ms"
+    - name: effective_cache_size
+      value: "2867MB"
+    - name: maintenance_work_mem
+      value: "204MB"
+    - name: max_wal_size
+      value: "10GB"

--- a/tembo-operator/yaml/sample-standard-backup.yaml
+++ b/tembo-operator/yaml/sample-standard-backup.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3creds
+data:
+  MINIO_ACCESS_KEY: dGVtYm8=
+  MINIO_SECRET_KEY: dGVtYm8xMjM0NQ==
+type: Opaque
+---
+apiVersion: coredb.io/v1alpha1
+kind: CoreDB
+metadata:
+  name: sample-standard-backup
+spec:
+  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  backup:
+    destinationPath: s3://tembo-backup/sample-standard-backup
+    retentionPolicy: "30"
+    schedule: 17 9 * * *
+    endpointURL: http://minio.minio.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: s3creds
+        key: MINIO_ACCESS_KEY
+      secretAccessKey:
+        name: s3creds
+        key: MINIO_SECRET_KEY
+  stop: false
+  stack:
+    name: Standard
+    postgres_config:
+      - name: autovacuum_vacuum_cost_limit
+        value: "-1"
+      - name: autovacuum_vacuum_scale_factor
+        value: "0.05"
+      - name: autovacuum_vacuum_insert_scale_factor
+        value: "0.05"
+      - name: autovacuum_analyze_scale_factor
+        value: "0.05"
+      - name: checkpoint_timeout
+        value: "10min"
+      - name: track_activity_query_size
+        value: "2048"
+      - name: wal_compression
+        value: 'on'
+      - name: track_io_timing
+        value: 'on'
+      - name: log_min_duration_statement # https://www.postgresql.org/docs/15/runtime-config-logging.html
+        value: "1000"
+      - name: pg_stat_statements.track
+        value: all
+      - name: shared_preload_libraries
+        value: pg_stat_statements
+  trunk_installs:
+    - name: pg_stat_statements
+      version: 1.10.0
+  extensions:
+    - name: pg_stat_statements
+      locations:
+        - database: postgres
+          enabled: true
+          version: 1.10.0
+  runtime_config:
+    - name: shared_buffers
+      value: "256MB"
+    - name: max_connections
+      value: "107"
+    - name: work_mem
+      value: "5MB"
+    - name: bgwriter_delay
+      value: "200ms"
+    - name: effective_cache_size
+      value: "716MB"
+    - name: maintenance_work_mem
+      value: "64MB"
+    - name: max_wal_size
+      value: "2GB"

--- a/tembo-operator/yaml/sample-standard-backup.yaml
+++ b/tembo-operator/yaml/sample-standard-backup.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: s3creds
-data:
-  MINIO_ACCESS_KEY: dGVtYm8=
-  MINIO_SECRET_KEY: dGVtYm8xMjM0NQ==
-type: Opaque
----
 apiVersion: coredb.io/v1alpha1
 kind: CoreDB
 metadata:

--- a/tembo-operator/yaml/sample-standard-restore.yaml
+++ b/tembo-operator/yaml/sample-standard-restore.yaml
@@ -1,13 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: s3creds
-  namespace: restore
-data:
-  MINIO_ACCESS_KEY: dGVtYm8=
-  MINIO_SECRET_KEY: dGVtYm8xMjM0NQ==
-type: Opaque
----
 apiVersion: coredb.io/v1alpha1
 kind: CoreDB
 metadata:

--- a/tembo-operator/yaml/sample-standard-restore.yaml
+++ b/tembo-operator/yaml/sample-standard-restore.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3creds
+  namespace: restore
+data:
+  MINIO_ACCESS_KEY: dGVtYm8=
+  MINIO_SECRET_KEY: dGVtYm8xMjM0NQ==
+type: Opaque
+---
+apiVersion: coredb.io/v1alpha1
+kind: CoreDB
+metadata:
+  name: sample-standard-restore
+  namespace: restore
+spec:
+  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  backup:
+    destinationPath: s3://tembo-backup/sample-standard-restore
+    retentionPolicy: "30"
+    schedule: 17 9 * * *
+    endpointURL: http://minio.minio.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: s3creds
+        key: MINIO_ACCESS_KEY
+      secretAccessKey:
+        name: s3creds
+        key: MINIO_SECRET_KEY
+  restore:
+    serverName: sample-standard-backup
+    recoveryTargetTime: "2023-09-26T23:30:29Z"
+    endpointURL: http://minio.minio.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: s3creds
+        key: MINIO_ACCESS_KEY
+      secretAccessKey:
+        name: s3creds
+        key: MINIO_SECRET_KEY
+  stop: false
+  stack:
+    name: Standard
+    postgres_config:
+      - name: autovacuum_vacuum_cost_limit
+        value: "-1"
+      - name: autovacuum_vacuum_scale_factor
+        value: "0.05"
+      - name: autovacuum_vacuum_insert_scale_factor
+        value: "0.05"
+      - name: autovacuum_analyze_scale_factor
+        value: "0.05"
+      - name: checkpoint_timeout
+        value: "10min"
+      - name: track_activity_query_size
+        value: "2048"
+      - name: wal_compression
+        value: 'on'
+      - name: track_io_timing
+        value: 'on'
+      - name: log_min_duration_statement
+        value: "1000"
+      - name: pg_stat_statements.track
+        value: all
+      - name: shared_preload_libraries
+        value: pg_stat_statements
+  trunk_installs:
+    - name: pg_stat_statements
+      version: 1.10.0
+  extensions:
+    - name: pg_stat_statements
+      locations:
+        - database: postgres
+          enabled: true
+          version: 1.10.0
+  runtime_config:
+    - name: shared_buffers
+      value: "256MB"
+    - name: max_connections
+      value: "107"
+    - name: work_mem
+      value: "5MB"
+    - name: bgwriter_delay
+      value: "200ms"
+    - name: effective_cache_size
+      value: "716MB"
+    - name: maintenance_work_mem
+      value: "64MB"
+    - name: max_wal_size
+      value: "2GB"


### PR DESCRIPTION
Restore work will be split up into a few different PR's.  This change adds basic restore capabilities into the controller.

* Add support to run Minio locally to test backup and restores with. ([TEM-1834](https://linear.app/tembo/issue/TEM-1834/add-ability-to-add-tests-for-backups-and-restores))
* Add integration test to run an instance, add some data, back it up then restore it and check if the data is on the new restored instance.
* Adds support into the operator for non-AWS S3 compatible object storage (Minio, DigitalOcean, etc)
* Basic support to restore an instance from a backup in the `CoreDBSpec`.

** Reconciling a set of extensions into the restored instance and Conductor support will come in a later PR's

fixes: [TEM-1379](https://linear.app/tembo/issue/TEM-1379/bootstrap-from-configuration-in-operator)