### PR TITLE
Add `--release` flag to `cargo run` in CI and Justfile

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -77,7 +77,7 @@ jobs:
           export ENABLE_BACKUP=false
           export DATA_PLANE_BASEDOMAIN=localhost
           # Start the operator in the background
-          cargo run > operator-output.txt 2>&1 &
+          cargo run --release > operator-output.txt 2>&1 &
           # Run the tests
           cargo test --jobs 1 -- --ignored --nocapture
       - name: Debugging information

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -108,7 +108,7 @@ run-telemetry: run-jaeger
 
 # run without opentelemetry
 run:
-  DATA_PLANE_BASEDOMAIN=localhost ENABLE_BACKUP=false RUST_LOG=info,kube=info,controller=info cargo run
+  DATA_PLANE_BASEDOMAIN=localhost ENABLE_BACKUP=false RUST_LOG=info,kube=info,controller=info cargo run --release
 
 run-jaeger:
 	docker run --rm -d --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:latest


### PR DESCRIPTION
Add `--release` to `cargo run`. This avoids running in debug mode, and prevents stack overflow when running the controller.