### PR TITLE
[bugfix] Requeue for `cluster.get` in `unfence_pod`

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -77,7 +77,7 @@ jobs:
           export ENABLE_BACKUP=false
           export DATA_PLANE_BASEDOMAIN=localhost
           # Start the operator in the background
-          cargo run --release > operator-output.txt 2>&1 &
+          cargo run > operator-output.txt 2>&1 &
           # Run the tests
           cargo test --jobs 1 -- --ignored --nocapture
       - name: Debugging information

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -108,7 +108,7 @@ run-telemetry: run-jaeger
 
 # run without opentelemetry
 run:
-  DATA_PLANE_BASEDOMAIN=localhost ENABLE_BACKUP=false RUST_LOG=info,kube=info,controller=info cargo run --release
+  DATA_PLANE_BASEDOMAIN=localhost ENABLE_BACKUP=false RUST_LOG=info,kube=info,controller=info cargo run
 
 run-jaeger:
 	docker run --rm -d --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:latest


### PR DESCRIPTION
- Add requeue when getting cluster in `unfence_pod` function. This resolves a stack overflow issue that arose in integration tests in certain PRs
- Drop `--release` flag from `cargo run` in Justfile and CI