### PR TITLE
Fix cluster.get in get_fenced_pods

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
- Add requeue when getting cluster in get_fenced_pods function. This resolves a stack overflow issue that arose in integration tests in certain PRs
- Similar to https://github.com/tembo-io/tembo-stacks/pull/278
