### PR TITLE
correcting irrefutable if let pattern

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
This fixes the warning that is now present after #278 was fixed.

```
Warning: irrefutable `if let` pattern
    --> src/cloudnativepg/cnpg.rs:1007:8
     |
1007 |     if let mut cluster_resource = co {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this pattern will always match, so the `if let` is useless
     = help: consider replacing the `if let` with a `let`
     = note: `#[warn(irrefutable_let_patterns)]` on by default
```