### PR TITLE
Use labels instead of annotations for namespace

### DIFF
--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -195,12 +195,10 @@ pub async fn create_namespace(
         "kind": "Namespace",
         "metadata": {
             "name": format!("{name}"),
-            "annotations": {
+            "labels": {
+                "tembo-pod-init.tembo.io/watch": "true",
                 "tembo.io/instance_id": instance_id,
                 "tembo.io/organization_id": organization_id
-            },
-            "labels": {
-                "tembo-pod-init.tembo.io/watch": "true"
             }
         }
     });


### PR DESCRIPTION
to look up namespaces we use labels instead of annotations https://docs.rs/kube/latest/kube/api/struct.ListParams.html