### PR TITLE
Remove resource requirement from minio

### DIFF
--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/testdata/minio.yaml
+++ b/tembo-operator/testdata/minio.yaml
@@ -2,6 +2,7 @@ mode: standalone
 persistence:
   enabled: true
   size: 10Gi
+resources: {}
 users:
   - accessKey: tembo
     secretKey: tembo12345


### PR DESCRIPTION
Minio by default as a requests for 16GB of memory.  This removes that requirement so it can run more normally on a local system.