### PR TITLE
Allow for configurable storage class in `just annotate`

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.10.9"
+version = "0.10.10"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -110,7 +110,7 @@ start-kind:
 	just install-crd
 	just install-cnpg
 	just install-tembo-pod-init
-	just annotate
+	just annotate {{STORAGE_CLASS_NAME}}
 	kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
 
 # install dependencies on a cluster

--- a/tembo-operator/justfile
+++ b/tembo-operator/justfile
@@ -4,6 +4,7 @@ VERSION := `git rev-parse HEAD`
 SEMVER_VERSION := `grep version Cargo.toml | awk -F"\"" '{print $2}' | head -n 1`
 NAMESPACE := "default"
 KUBE_VERSION := env_var_or_default('KUBE_VERSION', '1.25.8')
+STORAGE_CLASS_NAME := "standard"
 
 default:
   @just --list --unsorted --color=always | rg -v "    default"
@@ -122,7 +123,7 @@ install-dependencies:
 	just install-crd
 	just install-cnpg
 	just install-tembo-pod-init
-	just annotate
+	just annotate {{STORAGE_CLASS_NAME}}
 	kubectl wait pods --for=condition=Ready --timeout=300s --all --all-namespaces
 
 # deploy the controller on a cluster
@@ -143,13 +144,13 @@ run-jaeger:
 	docker run --rm -d --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:latest
 
 # annotate namespace to allow for tests
-annotate:
+annotate STORAGE_CLASS_NAME:
 	kubectl label namespace {{NAMESPACE}} safe-to-run-coredb-tests=true
 	kubectl create namespace cnpg-test || true
 	kubectl label namespace cnpg-test safe-to-run-coredb-tests=true
 	kubectl label namespace cnpg-test "tembo-pod-init.tembo.io/watch"="true"
 	kubectl delete pods -n tembo-pod-init --all
-	kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
+	kubectl patch storageclass {{STORAGE_CLASS_NAME}} -p '{"allowVolumeExpansion": true}'
 
 
 # run tests


### PR DESCRIPTION
Allow for configurable storage class in `just annotate`. Examples:
- `just --set STORAGE_CLASS_NAME gp2 install-dependencies`
- `just annotate gp2`

Related to:
- https://github.com/tembo-io/website/pull/106