### PR TITLE
Add `pooler_host` to `ConnectionInfo` in conductor

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.10.11"
+version = "0.11.4"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.11.4"
+version = "0.11.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -277,11 +277,13 @@ pub async fn get_pg_conn(
     let (app_user, app_pw) = get_field_value_from_secret(app_data)?;
 
     let host = format!("{name}.{basedomain}");
+    let pooler_host = format!("{name}-pooler.{basedomain}");
 
     // Create ConnectionInfo for the postgres user
     // The user and password are base64 encoded when passed back to the control-plane
     let postgres_conn = types::ConnectionInfo {
         host: host.clone(),
+        pooler_host: pooler_host.clone(),
         port: 5432,
         user: postgres_user,
         password: postgres_pw,

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -255,6 +255,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                     client.clone(),
                     &namespace,
                     &data_plane_basedomain,
+                    &coredb_spec,
                 )
                 .await
                 {
@@ -424,8 +425,13 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                     }
                 };
 
-                let conn_info =
-                    get_pg_conn(client.clone(), &namespace, &data_plane_basedomain).await;
+                let conn_info = get_pg_conn(
+                    client.clone(),
+                    &namespace,
+                    &data_plane_basedomain,
+                    &current_resource.spec,
+                )
+                .await;
 
                 types::StateToControlPlane {
                     data_plane_id: read_msg.message.data_plane_id,

--- a/conductor/src/status_reporter.rs
+++ b/conductor/src/status_reporter.rs
@@ -99,7 +99,9 @@ async fn send_status_update(
         }
     };
 
-    let conn_info = match get_pg_conn(client, &namespace, &data_plane_basedomain).await {
+    let conn_info = match get_pg_conn(client, &namespace, &data_plane_basedomain, &coredb.spec)
+        .await
+    {
         Ok(conn_info) => conn_info,
         Err(_) => {
             info!("Could not get connection info for CoreDB {}, skipping status update. This can be normal for a few seconds when the resource is initially created, and when the instance is being deleted.", coredb_name);

--- a/conductor/src/types.rs
+++ b/conductor/src/types.rs
@@ -54,7 +54,7 @@ pub struct OrgInstId {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConnectionInfo {
     pub host: String,
-    pub pooler_host: String,
+    pub pooler_host: Option<String>,
     pub port: u16,
     pub user: String,
     pub password: String,

--- a/conductor/src/types.rs
+++ b/conductor/src/types.rs
@@ -54,6 +54,7 @@ pub struct OrgInstId {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConnectionInfo {
     pub host: String,
+    pub pooler_host: String,
     pub port: u16,
     pub user: String,
     pub password: String,


### PR DESCRIPTION
Add `pooler_host` field to `ConnectionInfo`. This information is passed up to the control-plane.