### PR TITLE
Forcibly set the app user and database into the ClusterBootstrapRecovery configuration 

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -333,6 +333,8 @@ pub fn cnpg_cluster_bootstrap_from_cdb(
         ClusterBootstrap {
             recovery: Some(ClusterBootstrapRecovery {
                 source: Some("tembo-recovery".to_string()),
+                database: Some("app".to_string()),
+                owner: Some("app".to_string()),
                 recovery_target: parsed_target_time.map(|target_time| {
                     ClusterBootstrapRecoveryRecoveryTarget {
                         target_time: Some(target_time),


### PR DESCRIPTION
According to [CNPG's docs](https://cloudnative-pg.io/documentation/1.21/cloudnative-pg.v1/#postgresql-cnpg-io-v1-BootstrapRecovery), the `app` user and database should be set by default.  For some reason they are being set as an empty string value instead.  For now, set the correct values in the operator.