### PR TITLE
Add convert methods to Extensions and TrunkInstall

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
For PITR to copy the extensions and trunk installs from the original instance we need to convert the `ExtensionStatus` and `TrunkInstallStatus` values back into usable types to input into the new restored instance.