### PR TITLE
Pick shorter name for common name

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/postgres_certificates.rs
+++ b/tembo-operator/src/postgres_certificates.rs
@@ -79,7 +79,7 @@ pub async fn reconcile_certificates(
         }
     };
 
-    let mut common_name = format!("{}-rw", coredb_name);
+    let common_name = format!("{}-rw", coredb_name);
     let mut dns_names = vec![
         format!("{}-rw", coredb_name),
         format!("{}-rw.{}", coredb_name, namespace),
@@ -95,7 +95,6 @@ pub async fn reconcile_certificates(
         Ok(basedomain) => {
             let extra_domain_name = format!("{}.{}", coredb_name, basedomain);
             dns_names.push(extra_domain_name.clone());
-            common_name = extra_domain_name;
         }
         Err(_) => {
             debug!("DATA_PLANE_BASEDOMAIN not set, not adding custom DNS name");


### PR DESCRIPTION
Longer-named instances have too long a common name, so we can use the shorter common name instead, and allow the domain name to live in the dnsNames configuration.