### PR TITLE
Correct issue with setting up CA and Secret for Connection Pooler

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -75,6 +75,7 @@ jobs:
         run: |
           set -xe
           export DATA_PLANE_BASEDOMAIN=localhost
+          export USE_SHARED_CA=1
           # Start the operator in the background
           cargo run > operator-output.txt 2>&1 &
           # Run the tests

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -127,7 +127,7 @@ impl CoreDB {
         // Fetch any metadata we need from Trunk
         reconcile_trunk_configmap(ctx.client.clone(), &ns).await?;
 
-        reconcile_certificates(ctx.client.clone(), &self.metadata.name.clone().unwrap(), &ns).await?;
+        reconcile_certificates(ctx.client.clone(), self, &ns).await?;
 
         // Ingress
         match std::env::var("DATA_PLANE_BASEDOMAIN") {

--- a/tembo-operator/src/extensions/database_queries.rs
+++ b/tembo-operator/src/extensions/database_queries.rs
@@ -95,17 +95,6 @@ name asc,
 enabled desc
 "#;
 
-pub const POOLER_CREATE_ROLE: &str = r#"CREATE ROLE cnpg_pooler_pgbouncer WITH LOGIN;"#;
-pub const POOLER_GRANT_TO_POSTGRES: &str = r#"GRANT CONNECT ON DATABASE postgres TO cnpg_pooler_pgbouncer;"#;
-pub const POOLER_GRANT_TO_APP: &str = r#"GRANT CONNECT ON DATABASE app TO cnpg_pooler_pgbouncer;"#;
-pub const POOLER_CREATE_FUNCTION: &str = r#"CREATE OR REPLACE FUNCTION user_search(uname TEXT)
-  RETURNS TABLE (usename name, passwd text)
-  LANGUAGE sql SECURITY DEFINER AS
-  'SELECT usename, passwd FROM pg_shadow WHERE usename=$1;';"#;
-pub const POOLER_REVOKE_ON_FUNCTION: &str = r#"REVOKE ALL ON FUNCTION user_search(text) FROM public;"#;
-pub const POOLER_GRANT_ON_FUNCTION: &str =
-    r#"GRANT EXECUTE ON FUNCTION user_search(text) TO cnpg_pooler_pgbouncer;"#;
-
 #[derive(Debug)]
 pub struct ExtRow {
     pub name: String,
@@ -353,7 +342,8 @@ pub async fn get_all_extensions(cdb: &CoreDB, ctx: Arc<Context>) -> Result<Vec<E
             };
             ext_hashmap
                 .entry((ext.name, ext.description))
-                .or_insert_with(Vec::new)
+                // .or_insert_with(Vec::new)
+                .or_default()
                 .push(extlocation);
         }
     }
@@ -527,34 +517,22 @@ mod tests {
          archive_mode          | off     |      |          |            |            | sighup  | enum    |        |         |         | on,off   | off      | off       |            |            | f";
         let config = parse_config_params(config_psql);
         assert_eq!(config.len(), 4);
-        assert_eq!(
-            config[0],
-            PgConfig {
-                name: "allow_system_table_mods".to_owned(),
-                value: "off".parse().unwrap(),
-            }
-        );
-        assert_eq!(
-            config[1],
-            PgConfig {
-                name: "application_name".to_owned(),
-                value: "".parse().unwrap(),
-            }
-        );
-        assert_eq!(
-            config[2],
-            PgConfig {
-                name: "archive_command".to_owned(),
-                value: "".parse().unwrap(),
-            }
-        );
-        assert_eq!(
-            config[3],
-            PgConfig {
-                name: "archive_mode".to_owned(),
-                value: "off".parse().unwrap(),
-            }
-        );
+        assert_eq!(config[0], PgConfig {
+            name: "allow_system_table_mods".to_owned(),
+            value: "off".parse().unwrap(),
+        });
+        assert_eq!(config[1], PgConfig {
+            name: "application_name".to_owned(),
+            value: "".parse().unwrap(),
+        });
+        assert_eq!(config[2], PgConfig {
+            name: "archive_command".to_owned(),
+            value: "".parse().unwrap(),
+        });
+        assert_eq!(config[3], PgConfig {
+            name: "archive_mode".to_owned(),
+            value: "off".parse().unwrap(),
+        });
     }
 
     #[test]


### PR DESCRIPTION
There is an issue with setting up the `-pooler` secret since we switched to using our own generated CA.  This PR is an attempt to add support to generate the certificate and secret the pooler requires to reconcile along with setting up the `cnpg_pooler_pgbouncer` role in the database.

fixes: [TEM-2039](https://linear.app/tembo/issue/TEM-2039/fix-pooler-mode-to-work-with-custom-certs)