### PR TITLE
add affinity, nodeSelector, toleration to operator helm chart

### DIFF
--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: coredb-operator
 description: Helm chart to deploy coredb operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/charts/tembo-operator/templates/deployment.yaml
+++ b/charts/tembo-operator/templates/deployment.yaml
@@ -42,3 +42,12 @@ spec:
             port: http
           initialDelaySeconds: 5
           periodSeconds: 5
+      nodeSelector:
+      {{ toYaml . | indent 2 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tembo-operator/values.yaml
+++ b/charts/tembo-operator/values.yaml
@@ -12,3 +12,12 @@ prometheusRule:
   enabled: true
 
 env: []
+
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+# https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}


### PR DESCRIPTION
Add an `affinity`, `toleration` and `nodeSelector` to the tembo-operator helm chart.

Fixes: [TEM-1886](https://linear.app/tembo/issue/TEM-1886/dedicated-node-pool-for-system-components-in-data-plane)