### PR TITLE
Add heartbeat table to ensure PITR will work on databases with no transactions

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -12,6 +12,7 @@ use crate::{
     deployment_postgres_exporter::reconcile_prometheus_exporter_deployment,
     exec::{ExecCommand, ExecOutput},
     extensions::database_queries::is_not_restarting,
+    heartbeat::reconcile_heartbeat,
     ingress::reconcile_postgres_ing_route_tcp,
     postgres_certificates::reconcile_certificates,
     psql::{PsqlCommand, PsqlOutput},
@@ -347,6 +348,7 @@ impl CoreDB {
 
         patch_cdb_status_merge(&coredbs, &name, patch_status).await?;
 
+        reconcile_heartbeat(self, ctx.clone()).await?;
         info!("Fully reconciled {}", self.name_any());
         // Check back every 60-90 seconds
         let jitter = rand::thread_rng().gen_range(0..30);

--- a/tembo-operator/src/heartbeat.rs
+++ b/tembo-operator/src/heartbeat.rs
@@ -37,11 +37,14 @@ BEGIN
         );';
     END IF;
 
+    -- Create index on latest_heartbeat column
+    EXECUTE 'CREATE INDEX idx_heartbeat ON tembo.heartbeat_table (latest_heartbeat);';
+
     -- Insert current UTC timestamp into heartbeat_table
     EXECUTE 'INSERT INTO tembo.heartbeat_table (latest_heartbeat)
         VALUES (CURRENT_TIMESTAMP AT TIME ZONE ''UTC'');';
 
-    -- Delete entries older than 30 days
+    -- Delete entries older than 7 days
     EXECUTE 'DELETE FROM tembo.heartbeat_table
         WHERE latest_heartbeat < (CURRENT_TIMESTAMP AT TIME ZONE ''UTC'' - INTERVAL ''7 days'');';
 

--- a/tembo-operator/src/heartbeat.rs
+++ b/tembo-operator/src/heartbeat.rs
@@ -1,0 +1,91 @@
+use crate::{apis::coredb_types::CoreDB, psql::PsqlOutput, Context};
+use kube::{runtime::controller::Action, ResourceExt};
+use std::sync::Arc;
+use tokio::time::Duration;
+use tracing::{debug, warn};
+
+const HEARTBEAT_FUNCTION: &str = r#"
+CREATE OR REPLACE FUNCTION run_heartbeat()
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE
+    schema_exists BOOLEAN;
+    table_exists BOOLEAN;
+BEGIN
+    -- Check if schema exists
+    SELECT EXISTS(
+        SELECT schema_name
+        FROM information_schema.schemata
+        WHERE schema_name = 'tembo'
+    ) INTO schema_exists;
+
+    -- Create schema if it doesn't exist
+    IF NOT schema_exists THEN
+        EXECUTE 'CREATE SCHEMA tembo;';
+    END IF;
+
+    -- Check if table exists within tembo schema
+    SELECT EXISTS(
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'tembo' AND table_name = 'heartbeat_table'
+    ) INTO table_exists;
+
+    -- Create table if it doesn't exist
+    IF NOT table_exists THEN
+        EXECUTE 'CREATE TABLE tembo.heartbeat_table (
+            latest_heartbeat TIMESTAMP NOT NULL
+        );';
+    END IF;
+
+    -- Insert current UTC timestamp into heartbeat_table
+    EXECUTE 'INSERT INTO tembo.heartbeat_table (latest_heartbeat)
+        VALUES (CURRENT_TIMESTAMP AT TIME ZONE ''UTC'');';
+
+    -- Delete entries older than 30 days
+    EXECUTE 'DELETE FROM tembo.heartbeat_table
+        WHERE latest_heartbeat < (CURRENT_TIMESTAMP AT TIME ZONE ''UTC'' - INTERVAL ''7 days'');';
+
+END;
+$$;
+"#;
+
+// reconcile_heartbeat is a function to run the setup_heartbeat function on the database instance
+// and then run the run_heartbeat function to insert a timestamp into the heartbeat_table.
+pub async fn reconcile_heartbeat(coredb: &CoreDB, ctx: Arc<Context>) -> Result<(), Action> {
+    // Match to make sure the HEARTBEAT_FUNCTION is installed on the database instance, requeue if
+    // it fails for some reason.
+    match setup_heartbeat(coredb, ctx.clone()).await {
+        Ok(_) => debug!(
+            "Successfully created setup_heartbeat function on instance {}",
+            coredb.name_any()
+        ),
+        Err(e) => {
+            warn!("Did not create setup_heartbeat function, will requeue: {:?}", e);
+            return Err(Action::requeue(Duration::from_secs(30)));
+        }
+    }
+    // Run the setup_pgbouncer function
+    coredb
+        .psql(
+            "SELECT run_heartbeat();".to_string(),
+            "postgres".to_string(),
+            ctx.clone(),
+        )
+        .await?;
+
+    Ok(())
+}
+
+// setup_heartbeat is a function to create a schema and table to write to everytime there is a
+// reconciliation loop.
+async fn setup_heartbeat(coredb: &CoreDB, ctx: Arc<Context>) -> Result<PsqlOutput, Action> {
+    // Install or update the HEARTBEAT_FUNCTION function on the database instance
+    let query = coredb
+        .psql(
+            HEARTBEAT_FUNCTION.to_string(),
+            "postgres".to_string(),
+            ctx.clone(),
+        )
+        .await?;
+    Ok(query)
+}

--- a/tembo-operator/src/heartbeat.rs
+++ b/tembo-operator/src/heartbeat.rs
@@ -30,15 +30,13 @@ BEGIN
         WHERE table_schema = 'tembo' AND table_name = 'heartbeat_table'
     ) INTO table_exists;
 
-    -- Create table if it doesn't exist
+    -- Create table and index if they don't exist
     IF NOT table_exists THEN
         EXECUTE 'CREATE TABLE tembo.heartbeat_table (
             latest_heartbeat TIMESTAMP NOT NULL
         );';
+        EXECUTE 'CREATE INDEX idx_heartbeat ON tembo.heartbeat_table (latest_heartbeat);';
     END IF;
-
-    -- Create index on latest_heartbeat column
-    EXECUTE 'CREATE INDEX idx_heartbeat ON tembo.heartbeat_table (latest_heartbeat);';
 
     -- Insert current UTC timestamp into heartbeat_table
     EXECUTE 'INSERT INTO tembo.heartbeat_table (latest_heartbeat)

--- a/tembo-operator/src/lib.rs
+++ b/tembo-operator/src/lib.rs
@@ -22,6 +22,7 @@ pub mod errors;
 pub mod cloudnativepg;
 mod deployment_postgres_exporter;
 #[cfg(test)] pub mod fixtures;
+pub mod heartbeat;
 pub mod ingress;
 pub mod traefik;
 pub use traefik::ingress_route_crd;

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -650,6 +650,17 @@ mod test {
         }
         assert!(found_extension);
 
+        // Check for heartbeat table and values
+        let sql_result = wait_until_psql_contains(
+            context.clone(),
+            coredb_resource.clone(),
+            "SELECT latest_heartbeat FROM tembo.heartbeat_table LIMIT 1".to_string(),
+            "postgres".to_string(),
+            true,
+        )
+        .await;
+        assert!(sql_result.success);
+
         // CLEANUP TEST
         // Cleanup CoreDB
         coredbs.delete(name, &Default::default()).await.unwrap();


### PR DESCRIPTION
We have seen where instances cannot be restored due to little to no transactions taking place, essentially an empty database.  The issue is that a date and time can be requested, but since there are no transactions during that time you want to restore to the restore will fail.

This adds a new schema (tembo) and a function that will write a timestamp to a table (heartbeat_timestamp).

Feel free to make suggestions on how things should be named.

fixes: [TEM-2132](https://linear.app/tembo/issue/TEM-2132/pitr-will-fail-on-instances-with-zero-transactions)