### PR TITLE
fix: Instances stuck restarting for non-interruptible, long-running queries

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/extensions/database_queries.rs
+++ b/tembo-operator/src/extensions/database_queries.rs
@@ -277,10 +277,7 @@ pub async fn is_not_restarting(cdb: &CoreDB, ctx: Arc<Context>, database: &str) 
 }
 
 fn get_pod_not_ready_duration(pod: Pod) -> Result<Option<Duration>, Box<dyn std::error::Error>> {
-    // Fetch the specific pod
     let status = pod.status.ok_or("Pod has no status information")?;
-
-    // Find the 'Ready' condition
     if let Some(conditions) = status.conditions {
         for condition in conditions {
             if condition.type_ == "Ready" {
@@ -292,23 +289,20 @@ fn get_pod_not_ready_duration(pod: Pod) -> Result<Option<Duration>, Box<dyn std:
                     let last_not_ready_time = last_transition.0;
                     let duration_since_not_ready = Utc::now() - last_not_ready_time;
 
-                    // Here we assume that `to_std` method exists for chrono::Duration
                     let std_duration = match duration_since_not_ready.to_std() {
                         Ok(duration) => duration,
                         Err(_) => {
                             error!("Failed to convert duration to std::time::Duration");
-                            return Ok(None); // If conversion fails, we return None
+                            return Ok(None);
                         }
                     };
 
-                    return Ok(Some(std_duration)); // Return the std::time::Duration
+                    return Ok(Some(std_duration));
                 }
                 break;
             }
         }
     }
-
-    // Pod is ready or does not have a Ready condition
     Ok(None)
 }
 

--- a/tembo-operator/src/extensions/database_queries.rs
+++ b/tembo-operator/src/extensions/database_queries.rs
@@ -10,7 +10,8 @@ use crate::{
     Context, RESTARTED_AT,
 };
 use chrono::{DateTime, Utc};
-use kube::{runtime::controller::Action, ResourceExt};
+use k8s_openapi::api::core::v1::Pod;
+use kube::{api::DeleteParams, runtime::controller::Action, Api, ResourceExt};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::{
@@ -189,19 +190,63 @@ pub async fn is_not_restarting(cdb: &CoreDB, ctx: Arc<Context>, database: &str) 
         })?
         .into();
 
-    let pg_postmaster = cdb
+    let pg_postmaster_result = cdb
         .psql(
             "select pg_postmaster_start_time();".to_owned(),
             database.to_owned(),
-            ctx,
+            ctx.clone(),
         )
-        .await?
-        .stdout
-        .ok_or_else(|| {
-            error!("{cdb_name}: select pg_postmaster_start_time() had no stdout");
+        .await;
 
+    let pg_postmaster = match pg_postmaster_result {
+        Ok(result) => result.stdout.ok_or_else(|| {
+            error!("{cdb_name}: select pg_postmaster_start_time() had no stdout");
             Action::requeue(Duration::from_secs(300))
-        })?;
+        })?,
+        Err(_) => {
+            let pod = cdb.primary_pod_cnpg_ready_or_not(ctx.client.clone()).await?;
+
+            let pod_not_ready_duration = match get_pod_not_ready_duration(pod.clone()) {
+                Ok(Some(duration)) => {
+                    warn!("Primary pod has not been ready for {:?}", duration);
+                    duration
+                }
+                Ok(None) => {
+                    warn!("{cdb_name}: Primary pod is ready or doesn't have a Ready condition, but we could not execute a command.");
+                    return Err(Action::requeue(Duration::from_secs(5)));
+                }
+                Err(_e) => {
+                    error!("{cdb_name}: Failed to determine how long the primary has not been ready");
+                    return Err(Action::requeue(Duration::from_secs(300)));
+                }
+            };
+
+            let pod_creation_timestamp = pod.metadata.creation_timestamp.ok_or_else(|| {
+                error!("{cdb_name}: Pod has no creation timestamp");
+                Action::requeue(Duration::from_secs(300))
+            })?;
+
+            let pod_age = Utc::now() - pod_creation_timestamp.0;
+
+            // Check if the pod is older than restarted_at, and the pod has been not ready for over 30 seconds
+            if pod_age > restarted_requested_at - Utc::now()
+                && pod_not_ready_duration > Duration::from_secs(30)
+            {
+                error!("{cdb_name}: Primary pod is older than restarted_at and has been not ready for over 30 seconds. Deleting the pod");
+                let pods_api = Api::<Pod>::namespaced(ctx.client.clone(), &pod.metadata.namespace.unwrap());
+                let delete_result = pods_api
+                    .delete(&pod.metadata.name.unwrap(), &DeleteParams::default())
+                    .await;
+                if let Err(e) = delete_result {
+                    error!("{cdb_name}: Failed to delete primary pod: {:?}", e);
+                    return Err(Action::requeue(Duration::from_secs(300)));
+                }
+                return Err(Action::requeue(Duration::from_secs(10)));
+            }
+
+            return Err(Action::requeue(Duration::from_secs(300)));
+        }
+    };
 
     let pg_postmaster_start_time = parse_psql_output(&pg_postmaster).ok_or_else(|| {
         error!("{cdb_name}: failed to parse pg_postmaster_start_time() output");
@@ -229,6 +274,42 @@ pub async fn is_not_restarting(cdb: &CoreDB, ctx: Arc<Context>, database: &str) 
         error!("Restart is not complete for {}, requeuing", cdb_name);
         Err(Action::requeue(Duration::from_secs(5)))
     }
+}
+
+fn get_pod_not_ready_duration(pod: Pod) -> Result<Option<Duration>, Box<dyn std::error::Error>> {
+    // Fetch the specific pod
+    let status = pod.status.ok_or("Pod has no status information")?;
+
+    // Find the 'Ready' condition
+    if let Some(conditions) = status.conditions {
+        for condition in conditions {
+            if condition.type_ == "Ready" {
+                if condition.status == "False" {
+                    // Extract the last transition time when the pod was not ready
+                    let last_transition = condition
+                        .last_transition_time
+                        .ok_or("No last transition time for Ready condition")?;
+                    let last_not_ready_time = last_transition.0;
+                    let duration_since_not_ready = Utc::now() - last_not_ready_time;
+
+                    // Here we assume that `to_std` method exists for chrono::Duration
+                    let std_duration = match duration_since_not_ready.to_std() {
+                        Ok(duration) => duration,
+                        Err(_) => {
+                            error!("Failed to convert duration to std::time::Duration");
+                            return Ok(None); // If conversion fails, we return None
+                        }
+                    };
+
+                    return Ok(Some(std_duration)); // Return the std::time::Duration
+                }
+                break;
+            }
+        }
+    }
+
+    // Pod is ready or does not have a Ready condition
+    Ok(None)
 }
 
 #[instrument(skip(psql_str))]

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1148,6 +1148,7 @@ mod test {
             }
         });
 
+
         // Use the patch method to update the Cluster resource
         let params = PatchParams::default();
         let patch = Patch::Merge(patch_json);
@@ -3462,7 +3463,7 @@ CREATE EVENT TRIGGER pgrst_watch
 
         let params = PatchParams::apply("tembo-integration-test");
         let patch = Patch::Apply(&coredb_json);
-        coredbs.patch(&name, &params, &patch).await.unwrap();
+        let coredb_resource = coredbs.patch(&name, &params, &patch).await.unwrap();
 
         // Wait for CNPG Pod to be created
         {
@@ -3475,6 +3476,31 @@ CREATE EVENT TRIGGER pgrst_watch
         // Ensure status.running is true
         assert!(status_running(&coredbs, &name).await);
         let initial_start_time = get_pg_start_time(&coredbs, &name, context.clone()).await;
+
+        // Initialize uninterruptible query
+        psql_with_retry(
+            context.clone(),
+            coredb_resource.clone(),
+            "\
+                CREATE EXTENSION IF NOT EXISTS plpython3u;
+                CREATE FUNCTION slow_fibonacci (n integer)
+                  RETURNS integer
+                AS $$
+                  def recur_fibo(n):
+                    if n <= 1:
+                      return n
+                    else:
+                      return(recur_fibo(n-1) + recur_fibo(n-2))
+                  return recur_fibo(n)
+                $$ LANGUAGE plpython3u;
+            "
+            .to_string(),
+        );
+        let stuck_query = coredb_resource.psql(
+            "SELECT slow_fibonacci(100);".to_string(),
+            "postgres".to_string(),
+            context.clone(),
+        );
 
         // Apply the annotation to restart Postgres
         {
@@ -3533,6 +3559,7 @@ CREATE EVENT TRIGGER pgrst_watch
                 "start time should've changed"
             );
         }
+        let _ = stuck_query.await;
 
         // Perform cleanup
         {

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -3478,7 +3478,7 @@ CREATE EVENT TRIGGER pgrst_watch
         let initial_start_time = get_pg_start_time(&coredbs, &name, context.clone()).await;
 
         // Initialize uninterruptible query
-        psql_with_retry(
+        let _ = psql_with_retry(
             context.clone(),
             coredb_resource.clone(),
             "\
@@ -3495,8 +3495,10 @@ CREATE EVENT TRIGGER pgrst_watch
                 $$ LANGUAGE plpython3u;
             "
             .to_string(),
-        );
-        let stuck_query = coredb_resource.psql(
+        )
+        .await;
+
+        let _stuck_query = coredb_resource.psql(
             "SELECT slow_fibonacci(100);".to_string(),
             "postgres".to_string(),
             context.clone(),
@@ -3559,7 +3561,6 @@ CREATE EVENT TRIGGER pgrst_watch
                 "start time should've changed"
             );
         }
-        let _ = stuck_query.await;
 
         // Perform cleanup
         {


### PR DESCRIPTION
If we have the restartedAt annotation, and the pod is older than this annotation, and the pod has been not ready for over 30 seconds, delete the pod.

This case is applicable to queries that do not handle the smart or fast postgres shutdown procedures. For example executing a PL/Python function that's long running is not interrupted even by fast shutdown, and instead needs immediate shutdown.