### PR TITLE
If connection pooler is enabled, a restore will not get fully reconciled.

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.15.5"
+version = "0.15.7"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.15.5"
+version = "0.15.7"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
Due to the manner and timing of when we reconcile the connection pooler, an issue can occur where the pooler cannot finish reconciliation and thus the extension reconciliation cannot be reconciled so that we can unfence the restored pod.  This check should allow for the pooler to not reconcile unless the main CNPG pod is fully online and ready for traffic.

fixes: [TEM-2133](https://linear.app/tembo/issue/TEM-2133/pitr-will-fail-if-connection-pooler-is-enabled-during-restore)