### PR TITLE
switch backup and wal compression to use snappy

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -20,8 +20,10 @@ use crate::{
             ClusterExternalClustersBarmanObjectStoreS3CredentialsRegion,
             ClusterExternalClustersBarmanObjectStoreS3CredentialsSecretAccessKey,
             ClusterExternalClustersBarmanObjectStoreS3CredentialsSessionToken,
-            ClusterExternalClustersBarmanObjectStoreWal, ClusterExternalClustersPassword, ClusterLogLevel,
-            ClusterManaged, ClusterManagedRoles, ClusterManagedRolesEnsure,
+            ClusterExternalClustersBarmanObjectStoreWal,
+            ClusterExternalClustersBarmanObjectStoreWalCompression,
+            ClusterExternalClustersBarmanObjectStoreWalEncryption, ClusterExternalClustersPassword,
+            ClusterLogLevel, ClusterManaged, ClusterManagedRoles, ClusterManagedRolesEnsure,
             ClusterManagedRolesPasswordSecret, ClusterMonitoring, ClusterMonitoringCustomQueriesConfigMap,
             ClusterNodeMaintenanceWindow, ClusterPostgresql, ClusterPostgresqlSyncReplicaElectionConstraint,
             ClusterPrimaryUpdateMethod, ClusterPrimaryUpdateStrategy, ClusterReplicationSlots,
@@ -72,7 +74,7 @@ fn create_cluster_backup_barman_data(cdb: &CoreDB) -> Option<ClusterBackupBarman
     };
 
     Some(ClusterBackupBarmanObjectStoreData {
-        compression: Some(ClusterBackupBarmanObjectStoreDataCompression::Bzip2),
+        compression: Some(ClusterBackupBarmanObjectStoreDataCompression::Snappy),
         encryption,
         immediate_checkpoint: Some(true),
         ..ClusterBackupBarmanObjectStoreData::default()
@@ -91,7 +93,7 @@ fn create_cluster_backup_barman_wal(cdb: &CoreDB) -> Option<ClusterBackupBarmanO
 
     if encryption.is_some() {
         Some(ClusterBackupBarmanObjectStoreWal {
-            compression: Some(ClusterBackupBarmanObjectStoreWalCompression::Bzip2),
+            compression: Some(ClusterBackupBarmanObjectStoreWalCompression::Snappy),
             encryption,
             max_parallel: Some(5),
         })
@@ -404,6 +406,8 @@ pub fn cnpg_cluster_bootstrap_from_cdb(
                 s3_credentials: Some(s3_credentials),
                 wal: Some(ClusterExternalClustersBarmanObjectStoreWal {
                     max_parallel: Some(5),
+                    encryption: Some(ClusterExternalClustersBarmanObjectStoreWalEncryption::Aes256),
+                    compression: Some(ClusterExternalClustersBarmanObjectStoreWalCompression::Snappy),
                     ..ClusterExternalClustersBarmanObjectStoreWal::default()
                 }),
                 server_name: Some(restore.server_name.clone()),


### PR DESCRIPTION
Due to issues decompressing bzip2 backups and WAL archives on large backups, switching to snappy compression allows for a faster compression and decompression time.

fixes: [TEM-2232](https://linear.app/tembo/issue/TEM-2232/restoring-for-s3-backups-is-slow-and-fails)