### PR TITLE
do not build with telemetry flag

### DIFF
--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/Dockerfile
+++ b/tembo-operator/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 
 RUN cargo build --release --target=x86_64-unknown-linux-musl
 
-FROM --platform=linux/amd64 quay.io/tembo/alpine:3.18.4
+FROM --platform=linux/amd64 quay.io/tembo/alpine:3.18.2
 
 RUN adduser -D nonroot
 

--- a/tembo-operator/Dockerfile
+++ b/tembo-operator/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /build
 
 COPY . .
 
-RUN cargo build --release --features=telemetry --target=x86_64-unknown-linux-musl
+RUN cargo build --release --target=x86_64-unknown-linux-musl
 
-FROM --platform=linux/amd64 quay.io/tembo/alpine:3.18.2
+FROM --platform=linux/amd64 quay.io/tembo/alpine:3.18.4
 
 RUN adduser -D nonroot
 


### PR DESCRIPTION
In a move to a more generic build, we need to disable the telemetry flag.  Eventually we will move this to a run time configuration, but for now we need to disable it so others outside of Tembo can run our operator in a more generic way that can be tailored to their infrastructure needs.

Fixes: [TEM-2276](https://linear.app/tembo/issue/TEM-2276/disable-telemetry-flag-in-operator)