### PR TITLE
move tembo operator deployment resources configurable

### DIFF
--- a/charts/tembo-operator/templates/deployment.yaml
+++ b/charts/tembo-operator/templates/deployment.yaml
@@ -21,13 +21,7 @@ spec:
       - name: coredb-controller
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 256Mi
-          requests:
-            cpu: 250m
-            memory: 100Mi
+        resources: {{ toYaml .Values.resources | nindent 10 }}
         ports:
         - name: http
           containerPort: 8080

--- a/charts/tembo-operator/values.yaml
+++ b/charts/tembo-operator/values.yaml
@@ -13,6 +13,7 @@ prometheusRule:
 
 env: []
 
+## Configure resource requests and limits
 resources:
   limits:
     cpu: 1000m

--- a/charts/tembo-operator/values.yaml
+++ b/charts/tembo-operator/values.yaml
@@ -13,6 +13,14 @@ prometheusRule:
 
 env: []
 
+resources:
+  limits:
+    cpu: 1000m
+    memory: 256Mi
+  requests:
+    cpu: 250m
+    memory: 100Mi
+
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 


### PR DESCRIPTION
temp operator deployments resources are hardcoded inside helm templates - this changes moves the hardcoding to values.yaml allowing users to override the values 